### PR TITLE
fix: resolve 36 SFC compiler and Vite plugin bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +860,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,10 +1167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.181"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libloading"
@@ -1992,6 +2023,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,9 +2260,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"
@@ -2553,12 +2594,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -2930,9 +2971,9 @@ checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2951,6 +2992,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -3001,7 +3048,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vize"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "clap",
  "dirs",
@@ -3036,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "vize_armature"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "compact_str",
  "serde",
@@ -3047,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_core"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3073,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_dom"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "insta",
  "phf",
@@ -3086,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_sfc"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "criterion",
  "insta",
@@ -3114,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_ssr"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "insta",
  "serde",
@@ -3126,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_vapor"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "insta",
  "serde",
@@ -3137,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "vize_canon"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "dashmap 6.1.0",
  "dirs",
@@ -3165,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "vize_carton"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "bitflags 2.10.0",
  "bumpalo",
@@ -3181,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "dashmap 6.1.0",
  "insta",
@@ -3203,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "vize_fresco"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3225,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "vize_glyph"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "criterion",
  "memchr",
@@ -3242,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "vize_maestro"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -3268,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "vize_musea"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "criterion",
  "insta",
@@ -3283,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "vize_patina"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "criterion",
  "insta",
@@ -3306,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "vize_relief"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "serde",
  "serde_json",
@@ -3316,7 +3363,7 @@ dependencies = [
 
 [[package]]
 name = "vize_test_runner"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "serde",
  "toml",
@@ -3328,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "vize_vitrine"
-version = "0.0.1-alpha.86"
+version = "0.0.1-alpha.100"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -3395,6 +3442,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3493,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -3740,6 +3830,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3861,6 +4033,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -32,6 +32,8 @@ pub struct CodegenContext {
     pub(super) slot_params: std::collections::HashSet<String>,
     /// When true, skip `is` prop in generate_props (used for dynamic components)
     pub(super) skip_is_prop: bool,
+    /// When true, skip scope_id attribute in props (used for component/slot elements)
+    pub(super) skip_scope_id: bool,
     /// When true, skip normalizeClass/normalizeStyle wrappers (inside mergeProps)
     pub(super) skip_normalize: bool,
 }
@@ -62,6 +64,7 @@ impl CodegenContext {
             cache_index: 0,
             slot_params: std::collections::HashSet::new(),
             skip_is_prop: false,
+            skip_scope_id: false,
             skip_normalize: false,
         }
     }

--- a/crates/vize_atelier_core/src/codegen/element.rs
+++ b/crates/vize_atelier_core/src/codegen/element.rs
@@ -19,7 +19,7 @@ use super::v_if::generate_if;
 
 /// Check if a template child node is whitespace-only text or a comment.
 /// Used to skip generating empty default slots for components.
-fn is_whitespace_or_comment(child: &TemplateChildNode<'_>) -> bool {
+pub(super) fn is_whitespace_or_comment(child: &TemplateChildNode<'_>) -> bool {
     match child {
         TemplateChildNode::Text(t) => t.content.trim().is_empty(),
         TemplateChildNode::Comment(_) => true,

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -195,15 +195,16 @@ pub fn capitalize_first(s: &str) -> String {
     capitalize(s).into()
 }
 
-/// Check if a component is a Vue built-in that should be imported directly
+/// Check if a component is a Vue built-in that should be imported directly.
+/// Handles both PascalCase and kebab-case tag names.
 pub fn is_builtin_component(name: &str) -> Option<RuntimeHelper> {
     match name {
-        "Teleport" => Some(RuntimeHelper::Teleport),
-        "Suspense" => Some(RuntimeHelper::Suspense),
-        "KeepAlive" => Some(RuntimeHelper::KeepAlive),
-        "BaseTransition" => Some(RuntimeHelper::BaseTransition),
-        "Transition" => Some(RuntimeHelper::Transition),
-        "TransitionGroup" => Some(RuntimeHelper::TransitionGroup),
+        "Teleport" | "teleport" => Some(RuntimeHelper::Teleport),
+        "Suspense" | "suspense" => Some(RuntimeHelper::Suspense),
+        "KeepAlive" | "keep-alive" => Some(RuntimeHelper::KeepAlive),
+        "BaseTransition" | "base-transition" => Some(RuntimeHelper::BaseTransition),
+        "Transition" | "transition" => Some(RuntimeHelper::Transition),
+        "TransitionGroup" | "transition-group" => Some(RuntimeHelper::TransitionGroup),
         _ => None,
     }
 }

--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -853,10 +853,12 @@ pub fn generate_directive_prop_with_static(
                 }
             }
             if let Some(exp) = &dir.exp {
-                if is_class && !ctx.skip_normalize {
-                    ctx.use_helper(RuntimeHelper::NormalizeClass);
-                    ctx.push("_normalizeClass(");
-                    // Merge static class if present
+                if is_class {
+                    if !ctx.skip_normalize {
+                        ctx.use_helper(RuntimeHelper::NormalizeClass);
+                        ctx.push("_normalizeClass(");
+                    }
+                    // Merge static class if present (needed even inside mergeProps)
                     if let Some(static_val) = static_class {
                         ctx.push("[\"");
                         ctx.push(static_val);
@@ -866,11 +868,15 @@ pub fn generate_directive_prop_with_static(
                     } else {
                         generate_expression(ctx, exp);
                     }
-                    ctx.push(")");
-                } else if is_style && !ctx.skip_normalize {
-                    ctx.use_helper(RuntimeHelper::NormalizeStyle);
-                    ctx.push("_normalizeStyle(");
-                    // Merge static style if present
+                    if !ctx.skip_normalize {
+                        ctx.push(")");
+                    }
+                } else if is_style {
+                    if !ctx.skip_normalize {
+                        ctx.use_helper(RuntimeHelper::NormalizeStyle);
+                        ctx.push("_normalizeStyle(");
+                    }
+                    // Merge static style if present (needed even inside mergeProps)
                     if let Some(static_val) = static_style {
                         ctx.push("[{");
                         // Parse static style and convert to object
@@ -899,7 +905,9 @@ pub fn generate_directive_prop_with_static(
                     } else {
                         generate_expression(ctx, exp);
                     }
-                    ctx.push(")");
+                    if !ctx.skip_normalize {
+                        ctx.push(")");
+                    }
                 } else {
                     generate_expression(ctx, exp);
                 }

--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -79,8 +79,13 @@ fn generate_von_object_exp(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
 
 /// Generate props object
 pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
-    // Clone scope_id to avoid borrow checker issues
-    let scope_id = ctx.options.scope_id.clone();
+    // Clone scope_id to avoid borrow checker issues.
+    // For component/slot elements, skip_scope_id suppresses the attribute.
+    let scope_id = if ctx.skip_scope_id {
+        None
+    } else {
+        ctx.options.scope_id.clone()
+    };
 
     // If no props but we have scope_id, generate object with just scope_id
     if props.is_empty() {
@@ -236,8 +241,13 @@ fn generate_props_object_inner(
         ctx.skip_normalize = true;
     }
 
-    // Clone scope_id to avoid borrow checker issues
-    let scope_id = ctx.options.scope_id.clone();
+    // Clone scope_id to avoid borrow checker issues.
+    // For component/slot elements, skip_scope_id suppresses the attribute.
+    let scope_id = if ctx.skip_scope_id {
+        None
+    } else {
+        ctx.options.scope_id.clone()
+    };
 
     // Check for static class/style that need to be merged with dynamic
     let static_class = props.iter().find_map(|p| {
@@ -404,6 +414,13 @@ fn generate_props_object_inner(
     let mut emitted_events: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for prop in props {
+        // Skip v-slot directive (handled separately in slots codegen)
+        if let PropNode::Directive(dir) = prop {
+            if dir.name == "slot" {
+                continue;
+            }
+        }
+
         // Skip `is` prop when generating for dynamic components
         if ctx.skip_is_prop {
             match prop {

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -99,6 +99,18 @@ pub fn has_slot_children(el: &ElementNode<'_>) -> bool {
         }
     }
 
+    // If children consist only of whitespace text and/or comments, skip slot generation.
+    // This matches Vue's official compiler behavior where `<Comp> </Comp>` does not
+    // produce a default slot (important for <router-view>, <transition>, etc.).
+    let has_meaningful_child = el.children.iter().any(|child| match child {
+        TemplateChildNode::Text(t) => !t.content.trim().is_empty(),
+        TemplateChildNode::Comment(_) => false,
+        _ => true,
+    });
+    if !has_meaningful_child {
+        return false;
+    }
+
     // Check for any children (default slot) or template slots
     true
 }

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -329,9 +329,10 @@ pub fn strip_typescript_from_expression(content: &str) -> std::string::String {
         // Find the semicolon at the end
         if let Some(end) = js_code[expr_start..].rfind(';') {
             let expr = &js_code[expr_start..expr_start + end];
-            // Remove surrounding parentheses if present
+            // Remove surrounding parentheses if they are a matching pair
+            // (the ones we added in the wrapping step)
             let expr = expr.trim();
-            if expr.starts_with('(') && expr.ends_with(')') {
+            if expr.starts_with('(') && expr.ends_with(')') && has_matching_outer_parens(expr) {
                 return expr[1..expr.len() - 1].to_string();
             }
             return expr.to_string();
@@ -340,6 +341,46 @@ pub fn strip_typescript_from_expression(content: &str) -> std::string::String {
 
     // Fallback: return original content
     content.to_string()
+}
+
+/// Check if the outer parentheses of a string are a matching pair.
+/// Returns false if the opening '(' is closed before the final ')'.
+/// e.g. "(isOpen) => foo(x)" → false (the first '(' matches the ')' after isOpen)
+/// e.g. "((isOpen) => foo(x))" → true (the first '(' matches the last ')')
+fn has_matching_outer_parens(s: &str) -> bool {
+    if !s.starts_with('(') || !s.ends_with(')') {
+        return false;
+    }
+    let inner = &s[1..s.len() - 1];
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut string_char = ' ';
+    let mut prev_char = ' ';
+    for ch in inner.chars() {
+        if in_string {
+            if ch == string_char && prev_char != '\\' {
+                in_string = false;
+            }
+            prev_char = ch;
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => {
+                in_string = true;
+                string_char = ch;
+            }
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+        prev_char = ch;
+    }
+    depth == 0
 }
 
 /// Prefix identifiers in expression with _ctx. for codegen
@@ -746,15 +787,44 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
                     return;
                 }
 
-                if let Some(prefix) = get_identifier_prefix(name, self.ctx) {
-                    if !prefix.is_empty() {
-                        let mut suffix = StdString::with_capacity(2 + prefix.len() + name.len());
-                        suffix.push_str(": ");
-                        suffix.push_str(prefix);
-                        suffix.push_str(name);
-                        self.suffix_rewrites.push((ident.span.end as usize, suffix));
-                        return;
+                let prefix = get_identifier_prefix(name, self.ctx);
+                let is_ref = self.is_ref_binding(name);
+                let needs_unref = self.needs_unref(name);
+
+                // Expand shorthand if identifier needs a prefix, is a ref binding,
+                // or needs _unref() wrapping.
+                // In inline mode, refs have no prefix but need .value, so shorthand
+                // { hasForm } must become { hasForm: hasForm.value } (not { hasForm.value }).
+                // Similarly, SetupLet/SetupMaybeRef bindings need _unref():
+                // { paddingBottom } must become { paddingBottom: _unref(paddingBottom) }
+                if prefix.is_some_and(|p| !p.is_empty()) || is_ref || needs_unref {
+                    let p = prefix.unwrap_or("");
+                    let (value_prefix, value_suffix) = if needs_unref && p.is_empty() {
+                        // Inline mode: wrap with _unref()
+                        ("_unref(", ")")
+                    } else if needs_unref && p == "$setup." {
+                        // Function mode: wrap with _unref($setup.)
+                        ("_unref($setup.", ")")
+                    } else if is_ref {
+                        ("", ".value")
+                    } else {
+                        ("", "")
+                    };
+                    let mut suffix = StdString::with_capacity(
+                        2 + value_prefix.len() + p.len() + name.len() + value_suffix.len(),
+                    );
+                    suffix.push_str(": ");
+                    suffix.push_str(value_prefix);
+                    if !needs_unref {
+                        suffix.push_str(p);
                     }
+                    suffix.push_str(name);
+                    suffix.push_str(value_suffix);
+                    self.suffix_rewrites.push((ident.span.end as usize, suffix));
+                    if needs_unref {
+                        self.used_unref = true;
+                    }
+                    return;
                 }
             }
         }

--- a/crates/vize_atelier_dom/tests/dom_snapshot.rs
+++ b/crates/vize_atelier_dom/tests/dom_snapshot.rs
@@ -76,6 +76,20 @@ mod v_if {
             r#"<div v-if="ok">yes</div><div v-else>no</div>"#
         ));
     }
+
+    #[test]
+    fn v_if_component_with_slot() {
+        insta::assert_snapshot!(get_compiled(
+            r#"<MyComponent v-if="ok"><span>slot content</span></MyComponent>"#
+        ));
+    }
+
+    #[test]
+    fn v_if_component_with_named_slot() {
+        insta::assert_snapshot!(get_compiled(
+            r#"<MyComponent v-if="ok"><template #header><h1>title</h1></template></MyComponent>"#
+        ));
+    }
 }
 
 // =============================================================================

--- a/crates/vize_atelier_dom/tests/dom_snapshot.rs
+++ b/crates/vize_atelier_dom/tests/dom_snapshot.rs
@@ -109,6 +109,20 @@ mod v_bind {
     fn dynamic_class() {
         insta::assert_snapshot!(get_compiled(r#"<div :class="cls"></div>"#));
     }
+
+    #[test]
+    fn merge_static_and_dynamic_class_with_vbind_object() {
+        insta::assert_snapshot!(get_compiled(
+            r#"<input v-bind="attrs" class="base" :class="stateClass" />"#
+        ));
+    }
+
+    #[test]
+    fn merge_static_and_dynamic_style_with_vbind_object() {
+        insta::assert_snapshot!(get_compiled(
+            r#"<input v-bind="attrs" style="color: red" :style="dynamicStyle" />"#
+        ));
+    }
 }
 
 // =============================================================================
@@ -147,6 +161,16 @@ mod v_show {
     #[test]
     fn simple_v_show() {
         insta::assert_snapshot!(get_compiled(r#"<div v-show="visible">content</div>"#));
+    }
+
+    #[test]
+    fn v_show_on_child_component() {
+        insta::assert_snapshot!(get_compiled(r#"<div><MyComponent v-show="visible" /></div>"#));
+    }
+
+    #[test]
+    fn v_show_on_root_component() {
+        insta::assert_snapshot!(get_compiled(r#"<MyComponent v-show="visible" />"#));
     }
 }
 

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__static_element__nested_elements.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__static_element__nested_elements.snap
@@ -2,7 +2,7 @@
 source: crates/vize_atelier_dom/tests/dom_snapshot.rs
 expression: "get_compiled(\"<div><span>hello</span></div>\")"
 ---
-const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, createElementVNode: _createElementVNode } = Vue
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("span", null, "hello")
 

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_bind__merge_static_and_dynamic_class_with_vbind_object.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_bind__merge_static_and_dynamic_class_with_vbind_object.snap
@@ -1,0 +1,11 @@
+---
+source: crates/vize_atelier_dom/tests/dom_snapshot.rs
+expression: "get_compiled(r#\"<input v-bind=\"attrs\" class=\"base\" :class=\"stateClass\" />\"#)"
+---
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, mergeProps: _mergeProps } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("input", _mergeProps(attrs, {
+    class: ["base", stateClass]
+  }), null, 16 /* FULL_PROPS */))
+}

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_bind__merge_static_and_dynamic_style_with_vbind_object.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_bind__merge_static_and_dynamic_style_with_vbind_object.snap
@@ -1,0 +1,11 @@
+---
+source: crates/vize_atelier_dom/tests/dom_snapshot.rs
+expression: "get_compiled(r#\"<input v-bind=\"attrs\" style=\"color: red\" :style=\"dynamicStyle\" />\"#)"
+---
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, mergeProps: _mergeProps } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("input", _mergeProps(attrs, {
+    style: [{"color":"red"}, dynamicStyle]
+  }), null, 16 /* FULL_PROPS */))
+}

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_if__v_if_component_with_named_slot.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_if__v_if_component_with_named_slot.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_dom/tests/dom_snapshot.rs
+expression: "get_compiled(r#\"<MyComponent v-if=\"ok\"><template #header><h1>title</h1></template></MyComponent>\"#)"
+---
+const { openBlock: _openBlock, createBlock: _createBlock, createElementVNode: _createElementVNode, createCommentVNode: _createCommentVNode, resolveComponent: _resolveComponent, withCtx: _withCtx } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("h1", null, "title")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+  
+  return (ok)
+    ? (_openBlock(), _createBlock(_component_MyComponent, { key: 0 }, {
+      header: _withCtx(() => [
+        _hoisted_1
+      ]),
+      _: 1 /* STABLE */
+    }))
+    : _createCommentVNode("v-if", true)
+}

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_if__v_if_component_with_slot.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_if__v_if_component_with_slot.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_dom/tests/dom_snapshot.rs
+expression: "get_compiled(r#\"<MyComponent v-if=\"ok\"><span>slot content</span></MyComponent>\"#)"
+---
+const { openBlock: _openBlock, createBlock: _createBlock, createElementVNode: _createElementVNode, createCommentVNode: _createCommentVNode, resolveComponent: _resolveComponent, withCtx: _withCtx } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("span", null, "slot content")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+  
+  return (ok)
+    ? (_openBlock(), _createBlock(_component_MyComponent, { key: 0 }, {
+      default: _withCtx(() => [
+        _hoisted_1
+      ]),
+      _: 1 /* STABLE */
+    }))
+    : _createCommentVNode("v-if", true)
+}

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_show__v_show_on_child_component.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_show__v_show_on_child_component.snap
@@ -1,0 +1,15 @@
+---
+source: crates/vize_atelier_dom/tests/dom_snapshot.rs
+expression: "get_compiled(r#\"<div><MyComponent v-show=\"visible\" /></div>\"#)"
+---
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, createVNode: _createVNode, resolveComponent: _resolveComponent, withDirectives: _withDirectives, vShow: _vShow } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+  
+  return (_openBlock(), _createElementBlock("div", null, [
+    _withDirectives(_createVNode(_component_MyComponent, {  }), [
+      [_vShow, visible]
+    ])
+  ]))
+}

--- a/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_show__v_show_on_root_component.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/dom_snapshot__v_show__v_show_on_root_component.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vize_atelier_dom/tests/dom_snapshot.rs
+expression: "get_compiled(r#\"<MyComponent v-show=\"visible\" />\"#)"
+---
+const { openBlock: _openBlock, createBlock: _createBlock, resolveComponent: _resolveComponent, withDirectives: _withDirectives, vShow: _vShow } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+  
+  return _withDirectives((_openBlock(), _createBlock(_component_MyComponent, null, null, 512 /* NEED_PATCH */)), [
+    [_vShow, visible]
+  ])
+}

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -91,7 +91,16 @@ pub fn compile_sfc(
 
         match template_result {
             Ok(template_code) => {
-                code = template_code;
+                // Wrap template-only SFC in a proper component with export default.
+                // Convert "export function render(" to "function render(" and add component wrapper.
+                let wrapped =
+                    template_code.replace("export function render(", "function render(");
+                let mut output = String::with_capacity(wrapped.len() + 128);
+                output.push_str(&wrapped);
+                output.push_str("\nconst _sfc_main = {};\n");
+                output.push_str("_sfc_main.render = render;\n");
+                output.push_str("export default _sfc_main;\n");
+                code = output;
             }
             Err(e) => errors.push(e),
         }

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -212,6 +212,39 @@ fn add_scope_id_to_template(template_line: &str, scope_id: &str) -> String {
     template_line.to_string()
 }
 
+/// Count net brace depth change ({  minus }) in a line, ignoring braces inside string literals.
+fn count_braces_outside_strings(line: &str) -> i32 {
+    let mut count: i32 = 0;
+    let mut in_string = false;
+    let mut string_char = '\0';
+    let mut escape = false;
+
+    for ch in line.chars() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if ch == '\\' && in_string {
+            escape = true;
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => {
+                if !in_string {
+                    in_string = true;
+                    string_char = ch;
+                } else if ch == string_char {
+                    in_string = false;
+                }
+            }
+            '{' if !in_string => count += 1,
+            '}' if !in_string => count -= 1,
+            _ => {}
+        }
+    }
+    count
+}
+
 /// Compact render body by removing unnecessary line breaks inside function calls and arrays
 #[allow(dead_code)]
 fn compact_render_body(render_body: &str) -> String {
@@ -219,6 +252,7 @@ fn compact_render_body(render_body: &str) -> String {
     let mut chars = render_body.chars().peekable();
     let mut paren_depth: i32 = 0;
     let mut bracket_depth: i32 = 0;
+    let mut brace_depth: i32 = 0;
     let mut in_string = false;
     let mut string_char = '\0';
     let mut in_template = false;
@@ -254,9 +288,20 @@ fn compact_render_body(render_body: &str) -> String {
                 bracket_depth = bracket_depth.saturating_sub(1);
                 result.push(ch);
             }
+            '{' if !in_string && !in_template => {
+                brace_depth += 1;
+                result.push(ch);
+            }
+            '}' if !in_string && !in_template => {
+                brace_depth = brace_depth.saturating_sub(1);
+                result.push(ch);
+            }
             '\n' => {
-                // If inside parentheses or brackets (but not strings or templates), replace newline with space
-                if (paren_depth > 0 || bracket_depth > 0) && !in_string && !in_template {
+                // If inside braces (block bodies), keep newlines to preserve statement separation
+                if brace_depth > 0 && !in_string && !in_template {
+                    result.push('\n');
+                } else if (paren_depth > 0 || bracket_depth > 0) && !in_string && !in_template {
+                    // Inside parentheses or brackets (but not braces), replace newline with space
                     result.push(' ');
                     // Skip following whitespace
                     while let Some(&next_ch) = chars.peek() {
@@ -301,13 +346,11 @@ pub(crate) fn extract_template_parts_full(template_code: &str) -> (String, Strin
         {
             in_render = true;
             brace_depth = 0;
-            brace_depth += line.matches('{').count() as i32;
-            brace_depth -= line.matches('}').count() as i32;
+            brace_depth += count_braces_outside_strings(line);
             render_fn.push_str(line);
             render_fn.push('\n');
         } else if in_render {
-            brace_depth += line.matches('{').count() as i32;
-            brace_depth -= line.matches('}').count() as i32;
+            brace_depth += count_braces_outside_strings(line);
             render_fn.push_str(line);
             render_fn.push('\n');
 
@@ -352,12 +395,9 @@ pub(crate) fn extract_template_parts(template_code: &str) -> (String, String, St
         {
             in_render = true;
             brace_depth = 0;
-            // Count opening braces
-            brace_depth += line.matches('{').count() as i32;
-            brace_depth -= line.matches('}').count() as i32;
+            brace_depth += count_braces_outside_strings(line);
         } else if in_render {
-            brace_depth += line.matches('{').count() as i32;
-            brace_depth -= line.matches('}').count() as i32;
+            brace_depth += count_braces_outside_strings(line);
 
             // Extract the return statement inside the render function (may span multiple lines)
             if in_return {
@@ -461,5 +501,66 @@ export function render(_ctx, _cache) {
         assert!(imports.contains("import"));
         assert!(hoisted.contains("_hoisted_1"));
         assert!(render_body.contains("_createVNode"));
+    }
+
+    // --- count_braces_outside_strings tests ---
+
+    #[test]
+    fn test_count_braces_normal() {
+        assert_eq!(count_braces_outside_strings("{ a: 1 }"), 0);
+        assert_eq!(count_braces_outside_strings("{"), 1);
+        assert_eq!(count_braces_outside_strings("}"), -1);
+        assert_eq!(count_braces_outside_strings("{ { }"), 1);
+    }
+
+    #[test]
+    fn test_count_braces_ignores_string_braces() {
+        // Braces inside single-quoted strings should be ignored
+        assert_eq!(count_braces_outside_strings("_toDisplayString(isArray.value ? ']' : '}')"), 0);
+        // Braces inside double-quoted strings
+        assert_eq!(count_braces_outside_strings(r#"var x = "{";"#), 0);
+        // Braces inside backtick strings
+        assert_eq!(count_braces_outside_strings("var x = `{`;"), 0);
+    }
+
+    #[test]
+    fn test_count_braces_mixed_string_and_code() {
+        // One real open brace + one string brace = net 1
+        assert_eq!(count_braces_outside_strings("if (x) { var s = '}'"), 1);
+    }
+
+    #[test]
+    fn test_count_braces_escaped_quotes() {
+        // Escaped quote inside string: '\'' should not break string tracking
+        assert_eq!(count_braces_outside_strings(r"var x = '\'' + '}'"), 0);
+    }
+
+    // --- extract_template_parts_full: brace-in-string bug ---
+
+    #[test]
+    fn test_extract_template_parts_full_brace_in_string() {
+        // Regression test: '}' inside a string literal should not truncate the render function
+        let template_code = r#"import { toDisplayString as _toDisplayString } from 'vue'
+
+export function render(_ctx, _cache) {
+  return _toDisplayString(isArray.value ? ']' : '}')
+}"#;
+
+        let (imports, _hoisted, render_fn) = extract_template_parts_full(template_code);
+
+        assert!(imports.contains("import"));
+        // The render function should contain the FULL body including the closing brace
+        assert!(
+            render_fn.contains("_toDisplayString"),
+            "Render function was truncated. Got:\n{}",
+            render_fn
+        );
+        // Verify the render function is properly closed (has final closing brace)
+        let trimmed = render_fn.trim();
+        assert!(
+            trimmed.ends_with('}'),
+            "Render function should end with closing brace. Got:\n{}",
+            render_fn
+        );
     }
 }

--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
+    "test:snapshot:bug40": "pnpm run build && node tests/rewrite-static-asset-urls.snapshot.test.mjs",
     "lint": "oxlint --deny-warnings --type-aware --tsconfig tsconfig.json",
     "lint:fix": "oxlint --type-aware --tsconfig tsconfig.json --fix",
     "fmt": "oxfmt --write src",

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -94,6 +94,15 @@ export interface VizeOptions {
   configFile?: string;
 
   /**
+   * Handle .vue files in node_modules (on-demand compilation).
+   * When true, vize will compile .vue files from node_modules that other plugins
+   * (like vite-plugin-vue-inspector) may import directly.
+   * Set to false if another Vue plugin (e.g. Nuxt) handles node_modules .vue files.
+   * @default true
+   */
+  handleNodeModulesVue?: boolean;
+
+  /**
    * Enable debug logging
    * @default false
    */

--- a/npm/vite-plugin-vize/tests/rewrite-static-asset-urls.snapshot.test.mjs
+++ b/npm/vite-plugin-vize/tests/rewrite-static-asset-urls.snapshot.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { __internal } from "../dist/index.js";
+
+function normalizeNewlines(text) {
+  return text.replace(/\r\n/g, "\n").trimEnd();
+}
+
+const input = [
+  'const _hoisted_1 = { src: "@/assets/images/logo.svg", alt: "" };',
+  'const _hoisted_2 = { "src": \'@/assets/icons/help.svg\' };',
+  'const _hoisted_3 = { src: "/assets/local.svg" };',
+].join("\n");
+
+const output = __internal.rewriteStaticAssetUrls(input, [
+  {
+    fromPrefix: "@/",
+    toPrefix: "/@fs/unused/",
+  },
+]);
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const snapshotPath = path.join(testDir, "snapshots", "rewrite-static-asset-urls.snap");
+const expected = fs.readFileSync(snapshotPath, "utf8");
+
+assert.strictEqual(
+  normalizeNewlines(output),
+  normalizeNewlines(expected),
+  "Bug-40 snapshot mismatch: static src alias rewrite output changed",
+);
+
+console.log("✅ rewriteStaticAssetUrls snapshot test passed");

--- a/npm/vite-plugin-vize/tests/snapshots/rewrite-static-asset-urls.snap
+++ b/npm/vite-plugin-vize/tests/snapshots/rewrite-static-asset-urls.snap
@@ -1,0 +1,5 @@
+import __vize_static_0 from "@/assets/images/logo.svg";
+import __vize_static_1 from "@/assets/icons/help.svg";
+const _hoisted_1 = { src: __vize_static_0, alt: "" };
+const _hoisted_2 = { "src": __vize_static_1 };
+const _hoisted_3 = { src: "/assets/local.svg" };

--- a/tests/fixtures/sfc/patches.toml
+++ b/tests/fixtures/sfc/patches.toml
@@ -691,3 +691,114 @@ const items = ref([{ id: 1, value: 0 }])
   </div>
 </template>
 """
+
+# =============================================================================
+# Dynamic component (<component :is="...">) codegen
+# Issue: <component :is="Component"> generated _component_component
+#        instead of _resolveDynamicComponent(Component)
+# Fix: Add dynamic component handling to non-block generate_element()
+# =============================================================================
+
+[[cases]]
+name = "dynamic component with v-slot destructure"
+input = """
+<script setup>
+import { RouterView } from 'vue-router'
+</script>
+
+<template>
+  <RouterView v-slot="{ Component }">
+    <component :is="Component" />
+  </RouterView>
+</template>
+"""
+
+# =============================================================================
+# Built-in component in v-if/v-for (Bug-28)
+# Issue: Built-in components inside v-if/v-for were sent to resolveComponent()
+# Fix: Add is_builtin_component check in v_if.rs and v_for.rs
+# =============================================================================
+
+[[cases]]
+name = "transition inside v-if should use builtin"
+input = """
+<script setup>
+import { ref } from 'vue'
+const show = ref(true)
+</script>
+
+<template>
+  <transition v-if="show" name="fade">
+    <div>content</div>
+  </transition>
+</template>
+"""
+
+[[cases]]
+name = "keep-alive inside v-for should use builtin"
+input = """
+<script setup>
+import { ref } from 'vue'
+const tabs = ref([{ id: 1, component: 'TabA' }])
+</script>
+
+<template>
+  <keep-alive v-for="tab in tabs" :key="tab.id">
+    <component :is="tab.component" />
+  </keep-alive>
+</template>
+"""
+
+# =============================================================================
+# Hyphenated component names in v-if (Bug-29)
+# Issue: <router-link v-if="cond"> generated _component_router-link
+#        which JS interprets as subtraction: _component_router - link
+# Fix: Replace hyphens with underscores in component variable names
+# =============================================================================
+
+[[cases]]
+name = "hyphenated component name in v-if"
+input = """
+<script setup>
+import { ref } from 'vue'
+const show = ref(true)
+</script>
+
+<template>
+  <router-link v-if="show" to="/">Home</router-link>
+</template>
+"""
+
+[[cases]]
+name = "hyphenated component in v-if v-else chain"
+input = """
+<script setup>
+import { ref } from 'vue'
+const mode = ref('link')
+</script>
+
+<template>
+  <router-link v-if="mode === 'link'" to="/">Link</router-link>
+  <router-view v-else />
+</template>
+"""
+
+# =============================================================================
+# scope_id should not be added to component VNode props (Bug-32)
+# Issue: <MyComponent class="foo" /> got data-v-xxx in its props
+# Fix: skip_scope_id flag for component/slot element props generation
+# =============================================================================
+
+[[cases]]
+name = "component should not receive scope_id in props"
+input = """
+<script setup>
+import MyComponent from './MyComponent.vue'
+</script>
+
+<template>
+  <div class="wrapper">
+    <MyComponent class="child" />
+  </div>
+</template>
+"""

--- a/tests/fixtures/vdom/component.toml
+++ b/tests/fixtures/vdom/component.toml
@@ -79,6 +79,30 @@ name = "TransitionGroup"
 input = '<TransitionGroup tag="ul"><li v-for="item in items" :key="item">{{ item }}</li></TransitionGroup>'
 
 # =============================================================================
+# Built-in components (kebab-case) - Bug-27
+# =============================================================================
+
+[[cases]]
+name = "keep-alive kebab-case"
+input = "<keep-alive><Component /></keep-alive>"
+
+[[cases]]
+name = "transition kebab-case"
+input = '<transition name="fade"><div v-if="show">content</div></transition>'
+
+[[cases]]
+name = "transition-group kebab-case"
+input = '<transition-group tag="ul"><li v-for="item in items" :key="item">{{ item }}</li></transition-group>'
+
+[[cases]]
+name = "teleport kebab-case"
+input = '<teleport to="body"><div>content</div></teleport>'
+
+[[cases]]
+name = "suspense kebab-case"
+input = "<suspense><Component /></suspense>"
+
+# =============================================================================
 # Dynamic components
 # =============================================================================
 

--- a/tests/snapshots/sfc/js/patches__arrow_function_with_multiple_statements_in_v_for.snap
+++ b/tests/snapshots/sfc/js/patches__arrow_function_with_multiple_statements_in_v_for.snap
@@ -14,7 +14,16 @@ export default {
 const items = ref([{ id: 1, value: 0 }])
 
 return (_ctx, _cache) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => { return (_openBlock(), _createElementBlock("div", { key: item.id }, [ _createElementVNode("button", { onClick: _cache[0] || (_cache[0] = () => { item.value++; console.log(item.id); }) }, _toDisplayString(item.value), 1 /* TEXT */) ])) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => {
+      return (_openBlock(), _createElementBlock("div", { key: item.id }, [
+        _createElementVNode("button", {
+          onClick: _cache[0] || (_cache[0] = () => {
+        item.value++;
+        console.log(item.id);
+      })
+        }, _toDisplayString(item.value), 1 /* TEXT */)
+      ]))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__complex_type_based_props_destructure_with_defaults.snap
+++ b/tests/snapshots/sfc/js/patches__complex_type_based_props_destructure_with_defaults.snap
@@ -19,7 +19,11 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { class: _normalizeClass({ disabled: __props.disabled }) }, [ _createElementVNode("h1", null, _toDisplayString(__props.title), 1 /* TEXT */), _createElementVNode("span", null, _toDisplayString(__props.count), 1 /* TEXT */), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => { return (_openBlock(), _createElementBlock("li", { key: item }, _toDisplayString(item), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */)) ]) ], 2 /* CLASS */))
+  return (_openBlock(), _createElementBlock("div", {
+      class: _normalizeClass({ disabled: __props.disabled })
+    }, [ _createElementVNode("h1", null, _toDisplayString(__props.title), 1 /* TEXT */), _createElementVNode("span", null, _toDisplayString(__props.count), 1 /* TEXT */), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => {
+          return (_openBlock(), _createElementBlock("li", { key: item }, _toDisplayString(item), 1 /* TEXT */))
+        }), 128 /* KEYED_FRAGMENT */)) ]) ], 2 /* CLASS */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__component_should_not_receive_scope_id_in_props.snap
+++ b/tests/snapshots/sfc/js/patches__component_should_not_receive_scope_id_in_props.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output
+---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createVNode as _createVNode } from "vue"
+
+import MyComponent from './MyComponent.vue'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", { class: "wrapper" }, [ _createVNode(MyComponent, { class: "child" }) ]))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__duplicate_imports_should_be_filtered.snap
+++ b/tests/snapshots/sfc/js/patches__duplicate_imports_should_be_filtered.snap
@@ -7,7 +7,6 @@ import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from "vue"
 
 import { ref } from 'vue'
-import { ref } from 'vue'
 import { computed } from 'vue'
 
 export default /*@__PURE__*/_defineComponent({

--- a/tests/snapshots/sfc/js/patches__duplicate_named_imports_should_be_filtered.snap
+++ b/tests/snapshots/sfc/js/patches__duplicate_named_imports_should_be_filtered.snap
@@ -7,7 +7,6 @@ import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString, unref as _unref } from "vue"
 
 import { cloneDeep } from 'lodash-es'
-import { cloneDeep } from 'lodash-es'
 import { merge } from 'lodash-es'
 
 export default /*@__PURE__*/_defineComponent({

--- a/tests/snapshots/sfc/js/patches__dynamic_component_with_v_slot_destructure.snap
+++ b/tests/snapshots/sfc/js/patches__dynamic_component_with_v_slot_destructure.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output
+---
+import { openBlock as _openBlock, createBlock as _createBlock, createVNode as _createVNode, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx } from "vue"
+
+import { RouterView } from 'vue-router'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createBlock(RouterView, null, {
+      default: _withCtx(({ Component }) => [
+        _createVNode(_resolveDynamicComponent(Component))
+      ]),
+      _: 1 /* STABLE */
+    }))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__es6_shorthand_in_computed_style.snap
+++ b/tests/snapshots/sfc/js/patches__es6_shorthand_in_computed_style.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 219
 expression: js_output
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, normalizeStyle as _normalizeStyle } from "vue"
@@ -14,7 +15,9 @@ const width = ref(100)
 const height = ref(50)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("div", { style: _normalizeStyle({ width.value, height.value }) }, "Styled", 4 /* STYLE */))
+  return (_openBlock(), _createElementBlock("div", {
+      style: _normalizeStyle({ width: width.value, height: height.value })
+    }, "Styled", 4 /* STYLE */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__es6_shorthand_in_event_handler_object.snap
+++ b/tests/snapshots/sfc/js/patches__es6_shorthand_in_event_handler_object.snap
@@ -15,7 +15,9 @@ const foo = ref('value')
 const bar = ref(123)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("div", { onClick: _cache[0] || (_cache[0] = $event => (_ctx.handleEvent({ foo.value, bar.value }))) }, "Test"))
+  return (_openBlock(), _createElementBlock("div", {
+      onClick: _cache[0] || (_cache[0] = $event => (_ctx.handleEvent({ foo: foo.value, bar: bar.value })))
+    }, "Test"))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__es6_shorthand_in_v_bind_object.snap
+++ b/tests/snapshots/sfc/js/patches__es6_shorthand_in_v_bind_object.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 219
 expression: js_output
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps } from "vue"
@@ -14,7 +15,7 @@ const disabled = ref(false)
 const type = ref('button')
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("button", _normalizeProps(_guardReactiveProps({ disabled.value, type.value })), "Click", 16 /* FULL_PROPS */))
+  return (_openBlock(), _createElementBlock("button", _normalizeProps(_guardReactiveProps({ disabled: disabled.value, type: type.value })), "Click", 16 /* FULL_PROPS */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__es6_shorthand_mixed_with_regular_properties.snap
+++ b/tests/snapshots/sfc/js/patches__es6_shorthand_mixed_with_regular_properties.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 219
 expression: js_output
 ---
 import { openBlock as _openBlock, createBlock as _createBlock, resolveComponent as _resolveComponent } from "vue"
@@ -15,7 +16,7 @@ const name = ref('test')
 return (_ctx, _cache) => {
   const _component_Component = _resolveComponent("Component")
 
-  return (_openBlock(), _createBlock(_component_Component, { options: { name.value, extra: 'value' } }, null, 8 /* PROPS */, ["options"]))
+  return (_openBlock(), _createBlock(_component_Component, { options: { name: name.value, extra: 'value' } }, null, 8 /* PROPS */, ["options"]))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__hyphenated_component_in_v_if_v_else_chain.snap
+++ b/tests/snapshots/sfc/js/patches__hyphenated_component_in_v_if_v_else_chain.snap
@@ -1,0 +1,28 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output
+---
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+
+import { ref } from 'vue'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const mode = ref('link')
+
+return (_ctx, _cache) => {
+  const _component_router_link = _resolveComponent("router-link")
+  const _component_router_view = _resolveComponent("router-view")
+
+  return (mode.value === 'link')
+      ? (_openBlock(), _createBlock(_component_router_link, {
+        key: 0,
+        to: "/"
+      }))
+      : (_openBlock(), _createBlock(_component_router_view, { key: 1 }))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__hyphenated_component_in_v_if_v_else_chain.snap
+++ b/tests/snapshots/sfc/js/patches__hyphenated_component_in_v_if_v_else_chain.snap
@@ -2,7 +2,7 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: js_output
 ---
-import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx } from "vue"
 
 import { ref } from 'vue'
 
@@ -20,6 +20,11 @@ return (_ctx, _cache) => {
       ? (_openBlock(), _createBlock(_component_router_link, {
         key: 0,
         to: "/"
+      }, {
+        default: _withCtx(() => [
+          _createTextVNode("Link")
+        ]),
+        _: 1 /* STABLE */
       }))
       : (_openBlock(), _createBlock(_component_router_view, { key: 1 }))
 }

--- a/tests/snapshots/sfc/js/patches__hyphenated_component_name_in_v_if.snap
+++ b/tests/snapshots/sfc/js/patches__hyphenated_component_name_in_v_if.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output
+---
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+
+import { ref } from 'vue'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const show = ref(true)
+
+return (_ctx, _cache) => {
+  const _component_router_link = _resolveComponent("router-link")
+
+  return (show.value)
+      ? (_openBlock(), _createBlock(_component_router_link, {
+        key: 0,
+        to: "/"
+      }))
+      : _createCommentVNode("v-if", true)
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__hyphenated_component_name_in_v_if.snap
+++ b/tests/snapshots/sfc/js/patches__hyphenated_component_name_in_v_if.snap
@@ -2,7 +2,7 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: js_output
 ---
-import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx } from "vue"
 
 import { ref } from 'vue'
 
@@ -19,6 +19,11 @@ return (_ctx, _cache) => {
       ? (_openBlock(), _createBlock(_component_router_link, {
         key: 0,
         to: "/"
+      }, {
+        default: _withCtx(() => [
+          _createTextVNode("Home")
+        ]),
+        _: 1 /* STABLE */
       }))
       : _createCommentVNode("v-if", true)
 }

--- a/tests/snapshots/sfc/js/patches__keep_alive_inside_v_for_should_use_builtin.snap
+++ b/tests/snapshots/sfc/js/patches__keep_alive_inside_v_for_should_use_builtin.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output
+---
+import { Fragment as _Fragment, KeepAlive as _KeepAlive, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, createVNode as _createVNode, resolveDynamicComponent as _resolveDynamicComponent, renderList as _renderList } from "vue"
+
+import { ref } from 'vue'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const tabs = ref([{ id: 1, component: 'TabA' }])
+
+return (_ctx, _cache) => {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs.value, (tab) => {
+      return (_openBlock(), _createBlock(_KeepAlive, { key: tab.id }, [
+        _createVNode(_resolveDynamicComponent(tab.component))
+      ]))
+    }), 128 /* KEYED_FRAGMENT */))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__let_variable_increment_in_handler.snap
+++ b/tests/snapshots/sfc/js/patches__let_variable_increment_in_handler.snap
@@ -13,7 +13,9 @@ export default {
 let value = $ref(10)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = $event => (value.value++)) }, _toDisplayString(_unref(value)), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = $event => (value.value++))
+    }, _toDisplayString(_unref(value)), 1 /* TEXT */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__multiline_arrow_function_in_event_handler.snap
+++ b/tests/snapshots/sfc/js/patches__multiline_arrow_function_in_event_handler.snap
@@ -14,7 +14,13 @@ export default {
 const count = ref(0)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = () => { const newValue = count.value + 1; count.value = _ctx.newValue; console.log('incremented'); }) }, "Increment"))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = () => {
+      const newValue = count.value + 1;
+      count.value = _ctx.newValue;
+      console.log('incremented');
+    })
+    }, "Increment"))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__props_destructure_with_type_based_defineprops_and_defaults.snap
+++ b/tests/snapshots/sfc/js/patches__props_destructure_with_type_based_defineprops_and_defaults.snap
@@ -17,7 +17,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { class: _normalizeClass([__props.color, __props.size]) }, "Styled", 2 /* CLASS */))
+  return (_openBlock(), _createElementBlock("div", {
+      class: _normalizeClass([__props.color, __props.size])
+    }, "Styled", 2 /* CLASS */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__setuplet_assignment_in_click_handler.snap
+++ b/tests/snapshots/sfc/js/patches__setuplet_assignment_in_click_handler.snap
@@ -13,7 +13,9 @@ export default {
 let count = $ref(0)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = $event => (count.value = _unref(count) + 1)) }, _toDisplayString(_unref(count)), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = $event => (count.value = _unref(count) + 1))
+    }, _toDisplayString(_unref(count)), 1 /* TEXT */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__top_level_await_generates_async_setup.snap
+++ b/tests/snapshots/sfc/js/patches__top_level_await_generates_async_setup.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 219
 expression: js_output
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString, unref as _unref } from "vue"
@@ -7,7 +8,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, toD
 
 export default {
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 const response = await fetch('/api/data')
 const data = await response.json()

--- a/tests/snapshots/sfc/js/patches__transition_inside_v_if_should_use_builtin.snap
+++ b/tests/snapshots/sfc/js/patches__transition_inside_v_if_should_use_builtin.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output
+---
+import { Transition as _Transition, openBlock as _openBlock, createBlock as _createBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode } from "vue"
+
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("div", null, "content")
+import { ref } from 'vue'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const show = ref(true)
+
+return (_ctx, _cache) => {
+  return (show.value)
+      ? (_openBlock(), _createBlock(_Transition, {
+        key: 0,
+        name: "fade"
+      }))
+      : _createCommentVNode("v-if", true)
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__transition_inside_v_if_should_use_builtin.snap
+++ b/tests/snapshots/sfc/js/patches__transition_inside_v_if_should_use_builtin.snap
@@ -2,7 +2,7 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: js_output
 ---
-import { Transition as _Transition, openBlock as _openBlock, createBlock as _createBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode } from "vue"
+import { Transition as _Transition, openBlock as _openBlock, createBlock as _createBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, withCtx as _withCtx } from "vue"
 
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("div", null, "content")
@@ -19,6 +19,11 @@ return (_ctx, _cache) => {
       ? (_openBlock(), _createBlock(_Transition, {
         key: 0,
         name: "fade"
+      }, {
+        default: _withCtx(() => [
+          _hoisted_1
+        ]),
+        _: 1 /* STABLE */
       }))
       : _createCommentVNode("v-if", true)
 }

--- a/tests/snapshots/sfc/js/patches__type_comparison_should_not_be_stripped.snap
+++ b/tests/snapshots/sfc/js/patches__type_comparison_should_not_be_stripped.snap
@@ -19,7 +19,10 @@ return (_ctx, _cache) => {
   return (_unref(isButton))
       ? (_openBlock(), _createElementBlock("button", { key: 0 }, "Button"))
       : (!_unref(isLink))
-        ? (_openBlock(), _createElementBlock("a", { key: 1, href: "#" }, "Link"))
+        ? (_openBlock(), _createElementBlock("a", {
+          key: 1,
+          href: "#"
+        }, "Link"))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/js/patches__v_else_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/js/patches__v_else_if_with_v_bind_object_spread.snap
@@ -17,10 +17,19 @@ const iconProps = { size: 24, color: 'blue' }
 
 return (_ctx, _cache) => {
   return (mode.value === 'view')
-      ? (_openBlock(), _createBlock(Icon, { key: 0, name: "eye" }))
+      ? (_openBlock(), _createBlock(Icon, {
+        key: 0,
+        name: "eye"
+      }))
       : (mode.value === 'edit')
-        ? (_openBlock(), _createBlock(Icon, _mergeProps(_unref(iconProps), { key: 1, name: "pencil" })))
-      : (_openBlock(), _createBlock(Icon, { key: 2, name: "default" }))
+        ? (_openBlock(), _createBlock(Icon, _mergeProps(_unref(iconProps), {
+          key: 1,
+          name: "pencil"
+        })))
+      : (_openBlock(), _createBlock(Icon, {
+        key: 2,
+        name: "default"
+      }))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_for_with_custom_directive_on_element.snap
+++ b/tests/snapshots/sfc/js/patches__v_for_with_custom_directive_on_element.snap
@@ -15,7 +15,11 @@ const list = [1, 2, 3]
 return (_ctx, _cache) => {
   const _directive_focus = _resolveDirective("focus")
 
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(list), (n) => { return (_openBlock(), _createElementBlock("span", { key: n }, _toDisplayString(n), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(list), (n) => {
+      return (_openBlock(), _createElementBlock("span", {
+        key: n
+      }, _toDisplayString(n), 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_for_with_v_click_outside.snap
+++ b/tests/snapshots/sfc/js/patches__v_for_with_v_click_outside.snap
@@ -19,7 +19,11 @@ function closeItem(id) {
 return (_ctx, _cache) => {
   const _directive_click_outside = _resolveDirective("click-outside")
 
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => { return (_openBlock(), _createElementBlock("div", { key: item.id }, "\n    " + _toDisplayString(item.name) + "\n  ", 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => {
+      return (_openBlock(), _createElementBlock("div", {
+        key: item.id
+      }, "\n    " + _toDisplayString(item.name) + "\n  ", 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_if_with_component_props.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_component_props.snap
@@ -16,7 +16,10 @@ const compiler = {}
 
 return (_ctx, _cache) => {
   return (show)
-      ? (_openBlock(), _createBlock(PatinaPlayground, { key: 0, compiler: _unref(compiler) }))
+      ? (_openBlock(), _createBlock(PatinaPlayground, {
+        key: 0,
+        compiler: _unref(compiler)
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 219
 expression: js_output
 ---
-import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, mergeProps as _mergeProps } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, mergeProps as _mergeProps, withCtx as _withCtx } from "vue"
 
 import { ref, computed } from 'vue'
 import Button from './Button.vue'
@@ -20,7 +19,12 @@ return (_ctx, _cache) => {
       ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
         key: 0,
         onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
-      })))
+      }), {
+        default: _withCtx(() => [
+          _createTextVNode("\n    Click me\n  ")
+        ]),
+        _: 1 /* STABLE */
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
@@ -17,7 +17,10 @@ const buttonProps = computed(() => ({ disabled: false, type: 'primary' }))
 
 return (_ctx, _cache) => {
   return (isActive.value)
-      ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, { key: 0, onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args))) })))
+      ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
+        key: 0,
+        onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
+      })))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_model_on_component.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_model_on_component.snap
@@ -17,7 +17,11 @@ const value = ref('')
 
 return (_ctx, _cache) => {
   return (visible.value)
-      ? (_openBlock(), _createBlock(MyInput, { key: 0, modelValue: value.value, "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((value).value = $event)) }))
+      ? (_openBlock(), _createBlock(MyInput, {
+        key: 0,
+        modelValue: value.value,
+        "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((value).value = $event))
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_model_on_input.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_model_on_input.snap
@@ -16,7 +16,10 @@ const text = ref('')
 
 return (_ctx, _cache) => {
   return (show.value)
-      ? (_openBlock(), _createElementBlock("input", { key: 0, , "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((text).value = $event)) }))
+      ? (_openBlock(), _createElementBlock("input", {
+        key: 0,
+        "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((text).value = $event))
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/js/patches__v_model_on_native_input_with_ref.snap
+++ b/tests/snapshots/sfc/js/patches__v_model_on_native_input_with_ref.snap
@@ -14,7 +14,9 @@ export default {
 const inputValue = ref('')
 
 return (_ctx, _cache) => {
-  return _withDirectives((_openBlock(), _createElementBlock("input", { "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((inputValue).value = $event)) }, null, 512 /* NEED_PATCH */)), [ [_vModelText, inputValue.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((inputValue).value = $event))
+    }, null, 512 /* NEED_PATCH */)), [ [_vModelText, inputValue.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_model_on_select_with_ref.snap
+++ b/tests/snapshots/sfc/js/patches__v_model_on_select_with_ref.snap
@@ -3,7 +3,7 @@ source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 assertion_line: 219
 expression: js_output
 ---
-import { openBlock as _openBlock, createElementBlock as _createElementBlock, withDirectives as _withDirectives, vModelSelect as _vModelSelect } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, withDirectives as _withDirectives, vModelSelect as _vModelSelect } from "vue"
 
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("option", { value: "option1" }, "Option 1")
@@ -17,7 +17,9 @@ export default {
 const selected = ref('option1')
 
 return (_ctx, _cache) => {
-  return _withDirectives((_openBlock(), _createElementBlock("select", { "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((selected).value = $event)) }, [ _hoisted_1, _hoisted_2 ], 512 /* NEED_PATCH */)), [ [_vModelSelect, selected.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("select", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((selected).value = $event))
+    }, [ _hoisted_1, _hoisted_2 ], 512 /* NEED_PATCH */)), [ [_vModelSelect, selected.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_slot_mixed_hyphenated_and_regular_names.snap
+++ b/tests/snapshots/sfc/js/patches__v_slot_mixed_hyphenated_and_regular_names.snap
@@ -13,7 +13,18 @@ export default {
 
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createBlock(Layout, null, { header: _withCtx(() => [ _createTextVNode("Regular") ]), "main-content": _withCtx(() => [ _createTextVNode("Hyphenated") ]), footer: _withCtx(() => [ _createTextVNode("Regular Again") ]), _: 1 /* STABLE */ }))
+  return (_openBlock(), _createBlock(Layout, null, {
+      header: _withCtx(() => [
+        _createTextVNode("Regular")
+      ]),
+      "main-content": _withCtx(() => [
+        _createTextVNode("Hyphenated")
+      ]),
+      footer: _withCtx(() => [
+        _createTextVNode("Regular Again")
+      ]),
+      _: 1 /* STABLE */
+    }))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_slot_with_hyphenated_name.snap
+++ b/tests/snapshots/sfc/js/patches__v_slot_with_hyphenated_name.snap
@@ -13,7 +13,12 @@ export default {
 
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createBlock(DataTable, null, { "item-header": _withCtx(({ item }) => [ _createElementVNode("span", null, _toDisplayString(item.title), 1 /* TEXT */) ]), _: 1 /* STABLE */ }))
+  return (_openBlock(), _createBlock(DataTable, null, {
+      "item-header": _withCtx(({ item }) => [
+        _createElementVNode("span", null, _toDisplayString(item.title), 1 /* TEXT */)
+      ]),
+      _: 1 /* STABLE */
+    }))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_slot_with_multiple_hyphenated_names.snap
+++ b/tests/snapshots/sfc/js/patches__v_slot_with_multiple_hyphenated_names.snap
@@ -13,7 +13,18 @@ export default {
 
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createBlock(Card, null, { "card-header": _withCtx(() => [ _createTextVNode("Header") ]), "card-body": _withCtx(() => [ _createTextVNode("Body") ]), "card-footer": _withCtx(() => [ _createTextVNode("Footer") ]), _: 1 /* STABLE */ }))
+  return (_openBlock(), _createBlock(Card, null, {
+      "card-header": _withCtx(() => [
+        _createTextVNode("Header")
+      ]),
+      "card-body": _withCtx(() => [
+        _createTextVNode("Body")
+      ]),
+      "card-footer": _withCtx(() => [
+        _createTextVNode("Footer")
+      ]),
+      _: 1 /* STABLE */
+    }))
 }
 }
 

--- a/tests/snapshots/sfc/ts/basic__custom_blocks.snap
+++ b/tests/snapshots/sfc/ts/basic__custom_blocks.snap
@@ -1,9 +1,14 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 173
 expression: ts_output
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-export function render(_ctx, _cache) {
+function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "Test"))
 }
+
+const _sfc_main = {};
+_sfc_main.render = render;
+export default _sfc_main;

--- a/tests/snapshots/sfc/ts/basic__multiple_style_blocks.snap
+++ b/tests/snapshots/sfc/ts/basic__multiple_style_blocks.snap
@@ -1,11 +1,16 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 173
 expression: ts_output
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 const _hoisted_1 = { class: "a b", "data-v-a6e04d40": "" }
 
-export function render(_ctx, _cache) {
+function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _hoisted_1, "Test"))
 }
+
+const _sfc_main = {};
+_sfc_main.render = render;
+export default _sfc_main;

--- a/tests/snapshots/sfc/ts/basic__template_only.snap
+++ b/tests/snapshots/sfc/ts/basic__template_only.snap
@@ -1,9 +1,14 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 173
 expression: ts_output
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-export function render(_ctx, _cache) {
+function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "Hello World"))
 }
+
+const _sfc_main = {};
+_sfc_main.render = render;
+export default _sfc_main;

--- a/tests/snapshots/sfc/ts/patches__arrow_function_with_multiple_statements_in_v_for.snap
+++ b/tests/snapshots/sfc/ts/patches__arrow_function_with_multiple_statements_in_v_for.snap
@@ -15,7 +15,16 @@ export default /*@__PURE__*/_defineComponent({
 const items = ref([{ id: 1, value: 0 }])
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => { return (_openBlock(), _createElementBlock("div", { key: item.id }, [ _createElementVNode("button", { onClick: _cache[0] || (_cache[0] = () => { item.value++; console.log(item.id); }) }, _toDisplayString(item.value), 1 /* TEXT */) ])) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => {
+      return (_openBlock(), _createElementBlock("div", { key: item.id }, [
+        _createElementVNode("button", {
+          onClick: _cache[0] || (_cache[0] = () => {
+        item.value++;
+        console.log(item.id);
+      })
+        }, _toDisplayString(item.value), 1 /* TEXT */)
+      ]))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__complex_type_based_props_destructure_with_defaults.snap
+++ b/tests/snapshots/sfc/ts/patches__complex_type_based_props_destructure_with_defaults.snap
@@ -19,7 +19,11 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { class: _normalizeClass({ disabled: __props.disabled }) }, [ _createElementVNode("h1", null, _toDisplayString(__props.title), 1 /* TEXT */), _createElementVNode("span", null, _toDisplayString(__props.count), 1 /* TEXT */), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => { return (_openBlock(), _createElementBlock("li", { key: item }, _toDisplayString(item), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */)) ]) ], 2 /* CLASS */))
+  return (_openBlock(), _createElementBlock("div", {
+      class: _normalizeClass({ disabled: __props.disabled })
+    }, [ _createElementVNode("h1", null, _toDisplayString(__props.title), 1 /* TEXT */), _createElementVNode("span", null, _toDisplayString(__props.count), 1 /* TEXT */), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => {
+          return (_openBlock(), _createElementBlock("li", { key: item }, _toDisplayString(item), 1 /* TEXT */))
+        }), 128 /* KEYED_FRAGMENT */)) ]) ], 2 /* CLASS */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__component_should_not_receive_scope_id_in_props.snap
+++ b/tests/snapshots/sfc/ts/patches__component_should_not_receive_scope_id_in_props.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createVNode as _createVNode } from "vue"
+
+import MyComponent from './MyComponent.vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", { class: "wrapper" }, [ _createVNode(MyComponent, { class: "child" }) ]))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__duplicate_imports_should_be_filtered.snap
+++ b/tests/snapshots/sfc/ts/patches__duplicate_imports_should_be_filtered.snap
@@ -7,7 +7,6 @@ import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from "vue"
 
 import { ref } from 'vue'
-import { ref } from 'vue'
 import { computed } from 'vue'
 
 export default /*@__PURE__*/_defineComponent({

--- a/tests/snapshots/sfc/ts/patches__duplicate_named_imports_should_be_filtered.snap
+++ b/tests/snapshots/sfc/ts/patches__duplicate_named_imports_should_be_filtered.snap
@@ -7,7 +7,6 @@ import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString, unref as _unref } from "vue"
 
 import { cloneDeep } from 'lodash-es'
-import { cloneDeep } from 'lodash-es'
 import { merge } from 'lodash-es'
 
 export default /*@__PURE__*/_defineComponent({

--- a/tests/snapshots/sfc/ts/patches__dynamic_component_with_v_slot_destructure.snap
+++ b/tests/snapshots/sfc/ts/patches__dynamic_component_with_v_slot_destructure.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, createVNode as _createVNode, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx } from "vue"
+
+import { RouterView } from 'vue-router'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createBlock(RouterView, null, {
+      default: _withCtx(({ Component }) => [
+        _createVNode(_resolveDynamicComponent(Component))
+      ]),
+      _: 1 /* STABLE */
+    }))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__es6_shorthand_in_computed_style.snap
+++ b/tests/snapshots/sfc/ts/patches__es6_shorthand_in_computed_style.snap
@@ -16,7 +16,9 @@ const width = ref(100)
 const height = ref(50)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { style: _normalizeStyle({ width.value, height.value }) }, "Styled", 4 /* STYLE */))
+  return (_openBlock(), _createElementBlock("div", {
+      style: _normalizeStyle({ width: width.value, height: height.value })
+    }, "Styled", 4 /* STYLE */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__es6_shorthand_in_event_handler_object.snap
+++ b/tests/snapshots/sfc/ts/patches__es6_shorthand_in_event_handler_object.snap
@@ -16,7 +16,9 @@ const foo = ref('value')
 const bar = ref(123)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { onClick: _cache[0] || (_cache[0] = ($event: any) => (_ctx.handleEvent({ foo.value, bar.value }))) }, "Test"))
+  return (_openBlock(), _createElementBlock("div", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (_ctx.handleEvent({ foo: foo.value, bar: bar.value })))
+    }, "Test"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__es6_shorthand_in_v_bind_object.snap
+++ b/tests/snapshots/sfc/ts/patches__es6_shorthand_in_v_bind_object.snap
@@ -16,7 +16,7 @@ const disabled = ref(false)
 const type = ref('button')
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", _normalizeProps(_guardReactiveProps({ disabled.value, type.value })), "Click", 16 /* FULL_PROPS */))
+  return (_openBlock(), _createElementBlock("button", _normalizeProps(_guardReactiveProps({ disabled: disabled.value, type: type.value })), "Click", 16 /* FULL_PROPS */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__es6_shorthand_mixed_with_regular_properties.snap
+++ b/tests/snapshots/sfc/ts/patches__es6_shorthand_mixed_with_regular_properties.snap
@@ -17,7 +17,7 @@ const name = ref('test')
 return (_ctx: any,_cache: any) => {
   const _component_Component = _resolveComponent("Component")
 
-  return (_openBlock(), _createBlock(_component_Component, { options: { name.value, extra: 'value' } }, null, 8 /* PROPS */, ["options"]))
+  return (_openBlock(), _createBlock(_component_Component, { options: { name: name.value, extra: 'value' } }, null, 8 /* PROPS */, ["options"]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__hyphenated_component_in_v_if_v_else_chain.snap
+++ b/tests/snapshots/sfc/ts/patches__hyphenated_component_in_v_if_v_else_chain.snap
@@ -3,7 +3,7 @@ source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx } from "vue"
 
 import { ref } from 'vue'
 
@@ -21,6 +21,11 @@ return (_ctx: any,_cache: any) => {
       ? (_openBlock(), _createBlock(_component_router_link, {
         key: 0,
         to: "/"
+      }, {
+        default: _withCtx(() => [
+          _createTextVNode("Link")
+        ]),
+        _: 1 /* STABLE */
       }))
       : (_openBlock(), _createBlock(_component_router_view, { key: 1 }))
 }

--- a/tests/snapshots/sfc/ts/patches__hyphenated_component_in_v_if_v_else_chain.snap
+++ b/tests/snapshots/sfc/ts/patches__hyphenated_component_in_v_if_v_else_chain.snap
@@ -1,0 +1,29 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+
+import { ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const mode = ref('link')
+
+return (_ctx: any,_cache: any) => {
+  const _component_router_link = _resolveComponent("router-link")
+  const _component_router_view = _resolveComponent("router-view")
+
+  return (mode.value === 'link')
+      ? (_openBlock(), _createBlock(_component_router_link, {
+        key: 0,
+        to: "/"
+      }))
+      : (_openBlock(), _createBlock(_component_router_view, { key: 1 }))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__hyphenated_component_name_in_v_if.snap
+++ b/tests/snapshots/sfc/ts/patches__hyphenated_component_name_in_v_if.snap
@@ -1,0 +1,28 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+
+import { ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const show = ref(true)
+
+return (_ctx: any,_cache: any) => {
+  const _component_router_link = _resolveComponent("router-link")
+
+  return (show.value)
+      ? (_openBlock(), _createBlock(_component_router_link, {
+        key: 0,
+        to: "/"
+      }))
+      : _createCommentVNode("v-if", true)
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__hyphenated_component_name_in_v_if.snap
+++ b/tests/snapshots/sfc/ts/patches__hyphenated_component_name_in_v_if.snap
@@ -3,7 +3,7 @@ source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, resolveComponent as _resolveComponent } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx } from "vue"
 
 import { ref } from 'vue'
 
@@ -20,6 +20,11 @@ return (_ctx: any,_cache: any) => {
       ? (_openBlock(), _createBlock(_component_router_link, {
         key: 0,
         to: "/"
+      }, {
+        default: _withCtx(() => [
+          _createTextVNode("Home")
+        ]),
+        _: 1 /* STABLE */
       }))
       : _createCommentVNode("v-if", true)
 }

--- a/tests/snapshots/sfc/ts/patches__keep_alive_inside_v_for_should_use_builtin.snap
+++ b/tests/snapshots/sfc/ts/patches__keep_alive_inside_v_for_should_use_builtin.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { Fragment as _Fragment, KeepAlive as _KeepAlive, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, createVNode as _createVNode, resolveDynamicComponent as _resolveDynamicComponent, renderList as _renderList } from "vue"
+
+import { ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const tabs = ref([{ id: 1, component: 'TabA' }])
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs.value, (tab) => {
+      return (_openBlock(), _createBlock(_KeepAlive, { key: tab.id }, [
+        _createVNode(_resolveDynamicComponent(tab.component))
+      ]))
+    }), 128 /* KEYED_FRAGMENT */))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__let_variable_increment_in_handler.snap
+++ b/tests/snapshots/sfc/ts/patches__let_variable_increment_in_handler.snap
@@ -14,7 +14,9 @@ export default /*@__PURE__*/_defineComponent({
 let value = $ref(10)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (value.value++)) }, _toDisplayString(_unref(value)), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (value.value++))
+    }, _toDisplayString(_unref(value)), 1 /* TEXT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__multiline_arrow_function_in_event_handler.snap
+++ b/tests/snapshots/sfc/ts/patches__multiline_arrow_function_in_event_handler.snap
@@ -15,7 +15,13 @@ export default /*@__PURE__*/_defineComponent({
 const count = ref(0)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = () => { const newValue = count.value + 1; count.value = _ctx.newValue; console.log('incremented'); }) }, "Increment"))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = () => {
+      const newValue = count.value + 1;
+      count.value = _ctx.newValue;
+      console.log('incremented');
+    })
+    }, "Increment"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__props_destructure_with_type_based_defineprops_and_defaults.snap
+++ b/tests/snapshots/sfc/ts/patches__props_destructure_with_type_based_defineprops_and_defaults.snap
@@ -17,7 +17,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { class: _normalizeClass([__props.color, __props.size]) }, "Styled", 2 /* CLASS */))
+  return (_openBlock(), _createElementBlock("div", {
+      class: _normalizeClass([__props.color, __props.size])
+    }, "Styled", 2 /* CLASS */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__setuplet_assignment_in_click_handler.snap
+++ b/tests/snapshots/sfc/ts/patches__setuplet_assignment_in_click_handler.snap
@@ -14,7 +14,9 @@ export default /*@__PURE__*/_defineComponent({
 let count = $ref(0)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (count.value = _unref(count) + 1)) }, _toDisplayString(_unref(count)), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (count.value = _unref(count) + 1))
+    }, _toDisplayString(_unref(count)), 1 /* TEXT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__top_level_await_generates_async_setup.snap
+++ b/tests/snapshots/sfc/ts/patches__top_level_await_generates_async_setup.snap
@@ -9,7 +9,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, toD
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 const response = await fetch('/api/data')
 const data = await response.json()

--- a/tests/snapshots/sfc/ts/patches__transition_inside_v_if_should_use_builtin.snap
+++ b/tests/snapshots/sfc/ts/patches__transition_inside_v_if_should_use_builtin.snap
@@ -3,7 +3,7 @@ source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { Transition as _Transition, openBlock as _openBlock, createBlock as _createBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode } from "vue"
+import { Transition as _Transition, openBlock as _openBlock, createBlock as _createBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, withCtx as _withCtx } from "vue"
 
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("div", null, "content")
@@ -20,6 +20,11 @@ return (_ctx: any,_cache: any) => {
       ? (_openBlock(), _createBlock(_Transition, {
         key: 0,
         name: "fade"
+      }, {
+        default: _withCtx(() => [
+          _hoisted_1
+        ]),
+        _: 1 /* STABLE */
       }))
       : _createCommentVNode("v-if", true)
 }

--- a/tests/snapshots/sfc/ts/patches__transition_inside_v_if_should_use_builtin.snap
+++ b/tests/snapshots/sfc/ts/patches__transition_inside_v_if_should_use_builtin.snap
@@ -1,0 +1,28 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { Transition as _Transition, openBlock as _openBlock, createBlock as _createBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode } from "vue"
+
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("div", null, "content")
+import { ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const show = ref(true)
+
+return (_ctx: any,_cache: any) => {
+  return (show.value)
+      ? (_openBlock(), _createBlock(_Transition, {
+        key: 0,
+        name: "fade"
+      }))
+      : _createCommentVNode("v-if", true)
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__type_comparison_should_not_be_stripped.snap
+++ b/tests/snapshots/sfc/ts/patches__type_comparison_should_not_be_stripped.snap
@@ -20,7 +20,10 @@ return (_ctx: any,_cache: any) => {
   return (_unref(isButton))
       ? (_openBlock(), _createElementBlock("button", { key: 0 }, "Button"))
       : (!_unref(isLink))
-        ? (_openBlock(), _createElementBlock("a", { key: 1, href: "#" }, "Link"))
+        ? (_openBlock(), _createElementBlock("a", {
+          key: 1,
+          href: "#"
+        }, "Link"))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__v_else_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/ts/patches__v_else_if_with_v_bind_object_spread.snap
@@ -18,10 +18,19 @@ const iconProps = { size: 24, color: 'blue' }
 
 return (_ctx: any,_cache: any) => {
   return (mode.value === 'view')
-      ? (_openBlock(), _createBlock(Icon, { key: 0, name: "eye" }))
+      ? (_openBlock(), _createBlock(Icon, {
+        key: 0,
+        name: "eye"
+      }))
       : (mode.value === 'edit')
-        ? (_openBlock(), _createBlock(Icon, _mergeProps(_unref(iconProps), { key: 1, name: "pencil" })))
-      : (_openBlock(), _createBlock(Icon, { key: 2, name: "default" }))
+        ? (_openBlock(), _createBlock(Icon, _mergeProps(_unref(iconProps), {
+          key: 1,
+          name: "pencil"
+        })))
+      : (_openBlock(), _createBlock(Icon, {
+        key: 2,
+        name: "default"
+      }))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_for_with_custom_directive_on_element.snap
+++ b/tests/snapshots/sfc/ts/patches__v_for_with_custom_directive_on_element.snap
@@ -16,7 +16,11 @@ const list = [1, 2, 3]
 return (_ctx: any,_cache: any) => {
   const _directive_focus = _resolveDirective("focus")
 
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(list), (n) => { return (_openBlock(), _createElementBlock("span", { key: n }, _toDisplayString(n), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(list), (n) => {
+      return (_openBlock(), _createElementBlock("span", {
+        key: n
+      }, _toDisplayString(n), 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_for_with_v_click_outside.snap
+++ b/tests/snapshots/sfc/ts/patches__v_for_with_v_click_outside.snap
@@ -20,7 +20,11 @@ function closeItem(id) {
 return (_ctx: any,_cache: any) => {
   const _directive_click_outside = _resolveDirective("click-outside")
 
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => { return (_openBlock(), _createElementBlock("div", { key: item.id }, "\n    " + _toDisplayString(item.name) + "\n  ", 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items.value, (item) => {
+      return (_openBlock(), _createElementBlock("div", {
+        key: item.id
+      }, "\n    " + _toDisplayString(item.name) + "\n  ", 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_if_with_component_props.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_component_props.snap
@@ -17,7 +17,10 @@ const compiler = {}
 
 return (_ctx: any,_cache: any) => {
   return (show)
-      ? (_openBlock(), _createBlock(PatinaPlayground, { key: 0, compiler: _unref(compiler) }))
+      ? (_openBlock(), _createBlock(PatinaPlayground, {
+        key: 0,
+        compiler: _unref(compiler)
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 196
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, mergeProps as _mergeProps } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, mergeProps as _mergeProps, withCtx as _withCtx } from "vue"
 
 import { ref, computed } from 'vue'
 import Button from './Button.vue'
@@ -21,7 +20,12 @@ return (_ctx: any,_cache: any) => {
       ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
         key: 0,
         onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
-      })))
+      }), {
+        default: _withCtx(() => [
+          _createTextVNode("\n    Click me\n  ")
+        ]),
+        _: 1 /* STABLE */
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
@@ -18,7 +18,10 @@ const buttonProps = computed(() => ({ disabled: false, type: 'primary' }))
 
 return (_ctx: any,_cache: any) => {
   return (isActive.value)
-      ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, { key: 0, onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args))) })))
+      ? (_openBlock(), _createBlock(Button, _mergeProps(buttonProps.value, {
+        key: 0,
+        onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
+      })))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_model_on_component.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_model_on_component.snap
@@ -18,7 +18,11 @@ const value = ref('')
 
 return (_ctx: any,_cache: any) => {
   return (visible.value)
-      ? (_openBlock(), _createBlock(MyInput, { key: 0, modelValue: value.value, "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((value).value = $event)) }))
+      ? (_openBlock(), _createBlock(MyInput, {
+        key: 0,
+        modelValue: value.value,
+        "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((value).value = $event))
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_model_on_input.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_model_on_input.snap
@@ -17,7 +17,10 @@ const text = ref('')
 
 return (_ctx: any,_cache: any) => {
   return (show.value)
-      ? (_openBlock(), _createElementBlock("input", { key: 0, , "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((text).value = $event)) }))
+      ? (_openBlock(), _createElementBlock("input", {
+        key: 0,
+        "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((text).value = $event))
+      }))
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__v_model_on_native_input_with_ref.snap
+++ b/tests/snapshots/sfc/ts/patches__v_model_on_native_input_with_ref.snap
@@ -15,7 +15,9 @@ export default /*@__PURE__*/_defineComponent({
 const inputValue = ref('')
 
 return (_ctx: any,_cache: any) => {
-  return _withDirectives((_openBlock(), _createElementBlock("input", { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((inputValue).value = $event)) }, null, 512 /* NEED_PATCH */)), [ [_vModelText, inputValue.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((inputValue).value = $event))
+    }, null, 512 /* NEED_PATCH */)), [ [_vModelText, inputValue.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_model_on_select_with_ref.snap
+++ b/tests/snapshots/sfc/ts/patches__v_model_on_select_with_ref.snap
@@ -4,7 +4,7 @@ assertion_line: 196
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createElementBlock as _createElementBlock, withDirectives as _withDirectives, vModelSelect as _vModelSelect } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, withDirectives as _withDirectives, vModelSelect as _vModelSelect } from "vue"
 
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("option", { value: "option1" }, "Option 1")
@@ -18,7 +18,9 @@ export default /*@__PURE__*/_defineComponent({
 const selected = ref('option1')
 
 return (_ctx: any,_cache: any) => {
-  return _withDirectives((_openBlock(), _createElementBlock("select", { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((selected).value = $event)) }, [ _hoisted_1, _hoisted_2 ], 512 /* NEED_PATCH */)), [ [_vModelSelect, selected.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("select", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((selected).value = $event))
+    }, [ _hoisted_1, _hoisted_2 ], 512 /* NEED_PATCH */)), [ [_vModelSelect, selected.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_slot_mixed_hyphenated_and_regular_names.snap
+++ b/tests/snapshots/sfc/ts/patches__v_slot_mixed_hyphenated_and_regular_names.snap
@@ -14,7 +14,18 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(Layout, null, { header: _withCtx(() => [ _createTextVNode("Regular") ]), "main-content": _withCtx(() => [ _createTextVNode("Hyphenated") ]), footer: _withCtx(() => [ _createTextVNode("Regular Again") ]), _: 1 /* STABLE */ }))
+  return (_openBlock(), _createBlock(Layout, null, {
+      header: _withCtx(() => [
+        _createTextVNode("Regular")
+      ]),
+      "main-content": _withCtx(() => [
+        _createTextVNode("Hyphenated")
+      ]),
+      footer: _withCtx(() => [
+        _createTextVNode("Regular Again")
+      ]),
+      _: 1 /* STABLE */
+    }))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_slot_with_hyphenated_name.snap
+++ b/tests/snapshots/sfc/ts/patches__v_slot_with_hyphenated_name.snap
@@ -14,7 +14,12 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(DataTable, null, { "item-header": _withCtx(({ item }) => [ _createElementVNode("span", null, _toDisplayString(item.title), 1 /* TEXT */) ]), _: 1 /* STABLE */ }))
+  return (_openBlock(), _createBlock(DataTable, null, {
+      "item-header": _withCtx(({ item }) => [
+        _createElementVNode("span", null, _toDisplayString(item.title), 1 /* TEXT */)
+      ]),
+      _: 1 /* STABLE */
+    }))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_slot_with_multiple_hyphenated_names.snap
+++ b/tests/snapshots/sfc/ts/patches__v_slot_with_multiple_hyphenated_names.snap
@@ -14,7 +14,18 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(Card, null, { "card-header": _withCtx(() => [ _createTextVNode("Header") ]), "card-body": _withCtx(() => [ _createTextVNode("Body") ]), "card-footer": _withCtx(() => [ _createTextVNode("Footer") ]), _: 1 /* STABLE */ }))
+  return (_openBlock(), _createBlock(Card, null, {
+      "card-header": _withCtx(() => [
+        _createTextVNode("Header")
+      ]),
+      "card-body": _withCtx(() => [
+        _createTextVNode("Body")
+      ]),
+      "card-footer": _withCtx(() => [
+        _createTextVNode("Footer")
+      ]),
+      _: 1 /* STABLE */
+    }))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__async_script_setup.snap
+++ b/tests/snapshots/sfc/ts/script_setup__async_script_setup.snap
@@ -9,7 +9,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, toD
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 const data = await fetch('/api').then(r => r.json())
 

--- a/tests/snapshots/sfc/ts/script_setup__computed_with_route_params.snap
+++ b/tests/snapshots/sfc/ts/script_setup__computed_with_route_params.snap
@@ -6,8 +6,8 @@ expression: ts_output
 import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from "vue"
 
-import { computed } from 'vue';
-import { useRoute } from 'vue-router';
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',

--- a/tests/snapshots/sfc/ts/script_setup__defineemits_with_typed_function_signatures.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineemits_with_typed_function_signatures.snap
@@ -15,7 +15,9 @@ export default /*@__PURE__*/_defineComponent({
 const emit = __emit
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (emit('submit'))) }, "Submit"))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (emit('submit')))
+    }, "Submit"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__defineemits_with_vue_33_shorthand.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineemits_with_vue_33_shorthand.snap
@@ -14,7 +14,9 @@ export default /*@__PURE__*/_defineComponent({
 const emit = __emit
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (emit('submit'))) }, "Submit"))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (emit('submit')))
+    }, "Submit"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__defineemits_without_assignment.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineemits_without_assignment.snap
@@ -14,7 +14,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (_ctx.$emit('update'))) }, "Click"))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (_ctx.$emit('update')))
+    }, "Click"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__definemodel_basic.snap
+++ b/tests/snapshots/sfc/ts/script_setup__definemodel_basic.snap
@@ -20,7 +20,9 @@ export default /*@__PURE__*/_defineComponent({
 const model = _useModel(__props, "modelValue")
 
 return (_ctx: any,_cache: any) => {
-  return _withDirectives((_openBlock(), _createElementBlock("input", { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((model).value = $event)) }, null, 512 /* NEED_PATCH */)), [ [_vModelText, model.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((model).value = $event))
+    }, null, 512 /* NEED_PATCH */)), [ [_vModelText, model.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__definemodel_with_name.snap
+++ b/tests/snapshots/sfc/ts/script_setup__definemodel_with_name.snap
@@ -20,7 +20,9 @@ export default /*@__PURE__*/_defineComponent({
 const title = _useModel(__props, "title")
 
 return (_ctx: any,_cache: any) => {
-  return _withDirectives((_openBlock(), _createElementBlock("input", { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((title).value = $event)) }, null, 512 /* NEED_PATCH */)), [ [_vModelText, title.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((title).value = $event))
+    }, null, 512 /* NEED_PATCH */)), [ [_vModelText, title.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__definemodel_with_options.snap
+++ b/tests/snapshots/sfc/ts/script_setup__definemodel_with_options.snap
@@ -20,7 +20,10 @@ export default /*@__PURE__*/_defineComponent({
 const count = _useModel(__props, "modelValue")
 
 return (_ctx: any,_cache: any) => {
-  return _withDirectives((_openBlock(), _createElementBlock("input", { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((count).value = $event)), type: "number" }, null, 512 /* NEED_PATCH */)), [ [_vModelText, count.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((count).value = $event)),
+      type: "number"
+    }, null, 512 /* NEED_PATCH */)), [ [_vModelText, count.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__defineprops_type_only_with_destructure_defaults.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineprops_type_only_with_destructure_defaults.snap
@@ -17,7 +17,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("span", { class: _normalizeClass([__props.color, __props.appearance]) }, [ _renderSlot(_ctx.$slots, "default") ], 2 /* CLASS */))
+  return (_openBlock(), _createElementBlock("span", {
+      class: _normalizeClass([__props.color, __props.appearance])
+    }, [ _renderSlot(_ctx.$slots, "default") ], 2 /* CLASS */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_basic.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_basic.snap
@@ -16,7 +16,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => { return (_openBlock(), _createElementBlock("div", { key: String(item) }, _toDisplayString(item), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => {
+      return (_openBlock(), _createElementBlock("div", { key: String(item) }, _toDisplayString(item), 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_complex_constraint.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_complex_constraint.snap
@@ -18,7 +18,9 @@ export default /*@__PURE__*/_defineComponent({
 const formData = ref<FormShape | null>(null)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("form", { onSubmit: _withModifiers(() => {}, ["prevent"]) }, [ _renderSlot(_ctx.$slots, "default", { data: formData.value }) ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
+  return (_openBlock(), _createElementBlock("form", {
+      onSubmit: _withModifiers(() => {}, ["prevent"])
+    }, [ _renderSlot(_ctx.$slots, "default", { data: formData.value }) ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_extends.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_extends.snap
@@ -16,7 +16,12 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("select", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.options, (opt) => { return (_openBlock(), _createElementBlock("option", { key: opt, value: opt }, _toDisplayString(opt), 9 /* TEXT, PROPS */, ["value"])) }), 128 /* KEYED_FRAGMENT */)) ]))
+  return (_openBlock(), _createElementBlock("select", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.options, (opt) => {
+        return (_openBlock(), _createElementBlock("option", {
+          key: opt,
+          value: opt
+        }, _toDisplayString(opt), 9 /* TEXT, PROPS */, ["value"]))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_multiple_type_params.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_multiple_type_params.snap
@@ -16,7 +16,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => { return (_openBlock(), _createElementBlock("div", { key: String(item[__props.keyField]) }, _toDisplayString(item), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => {
+      return (_openBlock(), _createElementBlock("div", { key: String(item[__props.keyField]) }, _toDisplayString(item), 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__interface_with_async_callback.snap
+++ b/tests/snapshots/sfc/ts/script_setup__interface_with_async_callback.snap
@@ -14,7 +14,8 @@ interface Props {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    onSubmit: { type: Object as PropType<(data: FormData) => Promise<void>; onError?: (error: Error) => void;>, required: true }
+    onSubmit: { type: Object as PropType<(data: FormData) => Promise<void>>, required: true },
+    onError: { type: Object as PropType<(error: Error) => void>, required: false }
   },
   setup(__props) {
 

--- a/tests/snapshots/sfc/ts/script_setup__interface_with_callback_function_type.snap
+++ b/tests/snapshots/sfc/ts/script_setup__interface_with_callback_function_type.snap
@@ -13,14 +13,16 @@ interface Props {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    refreshMethod: { type: Object as PropType<(loaded: Function) => Promise<void> | void;>, required: true }
+    refreshMethod: { type: Object as PropType<(loaded: Function) => Promise<void> | void>, required: true }
   },
   setup(__props) {
 
 const props = __props
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", { onClick: _cache[0] || (_cache[0] = props.refreshMethod(() => {})) }, "Refresh"))
+  return (_openBlock(), _createElementBlock("div", {
+      onClick: _cache[0] || (_cache[0] = props.refreshMethod(() => {}))
+    }, "Refresh"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__multiple_top_level_await_calls.snap
+++ b/tests/snapshots/sfc/ts/script_setup__multiple_top_level_await_calls.snap
@@ -9,7 +9,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, toD
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 const user = await fetchUser()
 const posts = await fetchPosts(user.id)

--- a/tests/snapshots/sfc/ts/script_setup__multiple_v_model_bindings_on_component_with_refs.snap
+++ b/tests/snapshots/sfc/ts/script_setup__multiple_v_model_bindings_on_component_with_refs.snap
@@ -6,8 +6,8 @@ expression: ts_output
 import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-import { ref } from 'vue';
-import Dialog from './Dialog.vue';
+import { ref } from 'vue'
+import Dialog from './Dialog.vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
@@ -17,7 +17,12 @@ const isOpen = ref(false);
 const formValue = ref('');
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(Dialog, { modelValue: isOpen.value, "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((isOpen).value = $event)), value: formValue.value, "onUpdate:value": _cache[1] || (_cache[1] = ($event: any) => ((formValue).value = $event)) }, null, 8 /* PROPS */, ["modelValue", "value"]))
+  return (_openBlock(), _createBlock(Dialog, {
+      modelValue: isOpen.value,
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((isOpen).value = $event)),
+      value: formValue.value,
+      "onUpdate:value": _cache[1] || (_cache[1] = ($event: any) => ((formValue).value = $event))
+    }, null, 8 /* PROPS */, ["modelValue", "value"]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__nested_v_if_with_ref_should_not_duplicate_value.snap
+++ b/tests/snapshots/sfc/ts/script_setup__nested_v_if_with_ref_should_not_duplicate_value.snap
@@ -8,7 +8,7 @@ import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _
 
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("span", null, "Alt")
-import { ref } from 'vue';
+import { ref } from 'vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
@@ -17,7 +17,10 @@ export default /*@__PURE__*/_defineComponent({
 const mode = ref<'a' | 'b'>('a');
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (true) ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [ (true) ? (_openBlock(), _createElementBlock("div", { key: 0 }, [ _createElementVNode("button", { class: _normalizeClass({ active: mode.value === 'a' }), onClick: _cache[0] || (_cache[0] = ($event: any) => (mode.value = 'b')) }, "Test", 2 /* CLASS */) ])) : (false) ? (_openBlock(), _createElementBlock("div", { key: 1 }, [ _hoisted_1 ])) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */)) : _createCommentVNode("v-if", true) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (true) ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [ (true) ? (_openBlock(), _createElementBlock("div", { key: 0 }, [ _createElementVNode("button", {
+                class: _normalizeClass({ active: mode.value === 'a' }),
+                onClick: _cache[0] || (_cache[0] = ($event: any) => (mode.value = 'b'))
+              }, "Test", 2 /* CLASS */) ])) : (false) ? (_openBlock(), _createElementBlock("div", { key: 1 }, [ _hoisted_1 ])) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */)) : _createCommentVNode("v-if", true) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_arrow_function_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_arrow_function_types.snap
@@ -9,7 +9,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    onSuccess: { type: Object as PropType<() => void onError: (error: Error) => void transform: (value: string) => number>, required: true }
+    onSuccess: { type: Function as PropType<() => void>, required: true },
+    onError: { type: Object as PropType<(error: Error) => void>, required: true },
+    transform: { type: Object as PropType<(value: string) => number>, required: true }
   },
   setup(__props) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_nested_object_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_nested_object_types.snap
@@ -9,7 +9,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, toD
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    config: { type: Object as PropType<{ state: string disabled: boolean onSuccess?: () => void>, required: true }
+    config: { type: Object as PropType<{ state: string disabled: boolean onSuccess?: () => void }>, required: true }
   },
   setup(__props) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_readonly_arrays.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_readonly_arrays.snap
@@ -15,7 +15,12 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("select", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.options, (opt) => { return (_openBlock(), _createElementBlock("option", { key: opt.value, value: opt.value }, _toDisplayString(opt.label), 9 /* TEXT, PROPS */, ["value"])) }), 128 /* KEYED_FRAGMENT */)) ]))
+  return (_openBlock(), _createElementBlock("select", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.options, (opt) => {
+        return (_openBlock(), _createElementBlock("option", {
+          key: opt.value,
+          value: opt.value
+        }, _toDisplayString(opt.label), 9 /* TEXT, PROPS */, ["value"]))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__reco_guidanceprogresslapinputbtn_pattern.snap
+++ b/tests/snapshots/sfc/ts/script_setup__reco_guidanceprogresslapinputbtn_pattern.snap
@@ -5,7 +5,7 @@ expression: ts_output
 import { defineComponent as _defineComponent, type PropType } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, withModifiers as _withModifiers } from "vue"
 
-import { computed } from 'vue';
+import { computed } from 'vue'
 
 interface GuidanceProgressFormInput {
   progressLap: number;
@@ -34,7 +34,11 @@ const isChangedProgressLap = computed(
 );
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { class: _normalizeClass([{ disabled: __props.disabled }, lapClass.value]), disabled: __props.disabled, onClick: _withModifiers(() => {}, ["prevent"]) }, "\n    " + _toDisplayString(__props.guidanceProgress.progressUnit.value) + "\n  ", 11 /* TEXT, CLASS, PROPS */, ["disabled", "onClick"]))
+  return (_openBlock(), _createElementBlock("button", {
+      class: _normalizeClass([{ disabled: __props.disabled }, lapClass.value]),
+      disabled: __props.disabled,
+      onClick: _withModifiers(() => {}, ["prevent"])
+    }, "\n    " + _toDisplayString(__props.guidanceProgress.progressUnit.value) + "\n  ", 11 /* TEXT, CLASS, PROPS */, ["disabled", "onClick"]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
+++ b/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
@@ -24,7 +24,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => { return (_openBlock(), _createElementBlock("div", { key: item.name }, "\n    " + _toDisplayString(item.label) + "\n  ", 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => {
+      return (_openBlock(), _createElementBlock("div", { key: item.name }, "\n    " + _toDisplayString(item.label) + "\n  ", 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__template_with_inline_handler.snap
+++ b/tests/snapshots/sfc/ts/script_setup__template_with_inline_handler.snap
@@ -15,7 +15,9 @@ export default /*@__PURE__*/_defineComponent({
 const count = ref(0)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (count.value++)) }, _toDisplayString(count.value), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("button", {
+      onClick: _cache[0] || (_cache[0] = ($event: any) => (count.value++))
+    }, _toDisplayString(count.value), 1 /* TEXT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__template_with_v_model_on_ref.snap
+++ b/tests/snapshots/sfc/ts/script_setup__template_with_v_model_on_ref.snap
@@ -15,7 +15,9 @@ export default /*@__PURE__*/_defineComponent({
 const msg = ref('')
 
 return (_ctx: any,_cache: any) => {
-  return _withDirectives((_openBlock(), _createElementBlock("input", { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((msg).value = $event)) }, null, 512 /* NEED_PATCH */)), [ [_vModelText, msg.value] ])
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((msg).value = $event))
+    }, null, 512 /* NEED_PATCH */)), [ [_vModelText, msg.value] ])
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__top_level_await.snap
+++ b/tests/snapshots/sfc/ts/script_setup__top_level_await.snap
@@ -10,7 +10,7 @@ import { ref } from 'vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 const count = ref(0)
 await new Promise(r => setTimeout(r, 100))

--- a/tests/snapshots/sfc/ts/script_setup__top_level_await_in_initialization.snap
+++ b/tests/snapshots/sfc/ts/script_setup__top_level_await_in_initialization.snap
@@ -10,7 +10,7 @@ import { ref } from 'vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 await initializeApp()
 const store = useStore()

--- a/tests/snapshots/sfc/ts/script_setup__top_level_await_with_destructuring.snap
+++ b/tests/snapshots/sfc/ts/script_setup__top_level_await_with_destructuring.snap
@@ -1,22 +1,21 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 150
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, toDisplayString as _toDisplayString } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, toDisplayString as _toDisplayString, unref as _unref } from "vue"
 
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
-  setup(__props) {
+  async setup(__props) {
 
 const { data, error } = await useFetch('/api/data')
 
 return (_ctx: any,_cache: any) => {
-  return (error)
-      ? (_openBlock(), _createElementBlock("div", { key: 0 }, "Error: " + _toDisplayString(error), 1 /* TEXT */))
-      : (_openBlock(), _createElementBlock("div", { key: 1 }, _toDisplayString(data), 1 /* TEXT */))
+  return (_unref(error))
+      ? (_openBlock(), _createElementBlock("div", { key: 0 }, "Error: " + _toDisplayString(_unref(error)), 1 /* TEXT */))
+      : (_openBlock(), _createElementBlock("div", { key: 1 }, _toDisplayString(_unref(data)), 1 /* TEXT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__v_else_if_chain_with_ref_bindings.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_else_if_chain_with_ref_bindings.snap
@@ -10,7 +10,7 @@ import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("h4", null, "AST")
 const _hoisted_2 = /*#__PURE__*/ _createElementVNode("h4", null, "Helpers")
 const _hoisted_3 = /*#__PURE__*/ _createElementVNode("h4", null, "SFC")
-import { ref, computed } from 'vue';
+import { ref, computed } from 'vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
@@ -22,7 +22,28 @@ const isTypeScript = computed(() => true);
 const codeViewMode = ref<'ts' | 'js'>('ts');
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (output.value) ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [ (activeTab.value === 'code') ? (_openBlock(), _createElementBlock("div", { key: 0, class: "code-output" }, [ (isTypeScript.value) ? (_openBlock(), _createElementBlock("div", { key: 0, class: "code-mode-toggle" }, [ _createElementVNode("button", { class: _normalizeClass(['btn', { active: codeViewMode.value === 'ts' }]), onClick: _cache[0] || (_cache[0] = ($event: any) => (codeViewMode.value = 'ts')) }, "TS", 2 /* CLASS */), _createElementVNode("button", { class: _normalizeClass(['btn', { active: codeViewMode.value === 'js' }]), onClick: _cache[1] || (_cache[1] = ($event: any) => (codeViewMode.value = 'js')) }, "JS", 2 /* CLASS */) ])) : _createCommentVNode("v-if", true) ])) : (activeTab.value === 'ast') ? (_openBlock(), _createElementBlock("div", { key: 1, class: "ast-output" }, [ _hoisted_1 ])) : (activeTab.value === 'helpers') ? (_openBlock(), _createElementBlock("div", { key: 2, class: "helpers-output" }, [ _hoisted_2 ])) : (activeTab.value === 'sfc') ? (_openBlock(), _createElementBlock("div", { key: 3, class: "sfc-output" }, [ _hoisted_3 ])) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */)) : _createCommentVNode("v-if", true) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (output.value) ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [ (activeTab.value === 'code') ? (_openBlock(), _createElementBlock("div", {
+              key: 0,
+              class: "code-output"
+            }, [ (isTypeScript.value) ? (_openBlock(), _createElementBlock("div", {
+                  key: 0,
+                  class: "code-mode-toggle"
+                }, [ _createElementVNode("button", {
+                    class: _normalizeClass(['btn', { active: codeViewMode.value === 'ts' }]),
+                    onClick: _cache[0] || (_cache[0] = ($event: any) => (codeViewMode.value = 'ts'))
+                  }, "TS", 2 /* CLASS */), _createElementVNode("button", {
+                    class: _normalizeClass(['btn', { active: codeViewMode.value === 'js' }]),
+                    onClick: _cache[1] || (_cache[1] = ($event: any) => (codeViewMode.value = 'js'))
+                  }, "JS", 2 /* CLASS */) ])) : _createCommentVNode("v-if", true) ])) : (activeTab.value === 'ast') ? (_openBlock(), _createElementBlock("div", {
+                key: 1,
+                class: "ast-output"
+              }, [ _hoisted_1 ])) : (activeTab.value === 'helpers') ? (_openBlock(), _createElementBlock("div", {
+                key: 2,
+                class: "helpers-output"
+              }, [ _hoisted_2 ])) : (activeTab.value === 'sfc') ? (_openBlock(), _createElementBlock("div", {
+                key: 3,
+                class: "sfc-output"
+              }, [ _hoisted_3 ])) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */)) : _createCommentVNode("v-if", true) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__v_for_with_imported_and_local_values.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_for_with_imported_and_local_values.snap
@@ -16,7 +16,14 @@ export default /*@__PURE__*/_defineComponent({
 const localItems = ref(['a', 'b', 'c'])
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", null, [ _createElementVNode("select", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(OPTIONS), (opt) => { return (_openBlock(), _createElementBlock("option", { key: opt.value, value: opt.value }, _toDisplayString(opt.label), 9 /* TEXT, PROPS */, ["value"])) }), 128 /* KEYED_FRAGMENT */)) ]), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(localItems.value, (item) => { return (_openBlock(), _createElementBlock("li", { key: item }, _toDisplayString(item), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */)) ]) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ _createElementVNode("select", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(OPTIONS), (opt) => {
+          return (_openBlock(), _createElementBlock("option", {
+            key: opt.value,
+            value: opt.value
+          }, _toDisplayString(opt.label), 9 /* TEXT, PROPS */, ["value"]))
+        }), 128 /* KEYED_FRAGMENT */)) ]), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(localItems.value, (item) => {
+          return (_openBlock(), _createElementBlock("li", { key: item }, _toDisplayString(item), 1 /* TEXT */))
+        }), 128 /* KEYED_FRAGMENT */)) ]) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__v_for_with_imported_values_should_use__unref.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_for_with_imported_values_should_use__unref.snap
@@ -14,7 +14,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(PRESETS), (preset) => { return (_openBlock(), _createElementBlock("div", { key: preset.name }, "\n    " + _toDisplayString(preset.label) + "\n  ", 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(PRESETS), (preset) => {
+      return (_openBlock(), _createElementBlock("div", { key: preset.name }, "\n    " + _toDisplayString(preset.label) + "\n  ", 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__v_for_with_multiple_imported_values.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_for_with_multiple_imported_values.snap
@@ -14,7 +14,16 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(CATEGORIES), (category) => { return (_openBlock(), _createElementBlock("section", { key: category.id }, [ _createElementVNode("h2", null, _toDisplayString(category.name), 1 /* TEXT */), _createElementVNode("ul", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ITEMS), (item) => { return (_openBlock(), _createElementBlock("li", { key: item.id }, _toDisplayString(item.name), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */)) ]) ])) }), 128 /* KEYED_FRAGMENT */)) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(CATEGORIES), (category) => {
+        return (_openBlock(), _createElementBlock("section", { key: category.id }, [
+          _createElementVNode("h2", null, _toDisplayString(category.name), 1 /* TEXT */),
+          _createElementVNode("ul", null, [
+            (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_unref(ITEMS), (item) => {
+              return (_openBlock(), _createElementBlock("li", { key: item.id }, _toDisplayString(item.name), 1 /* TEXT */))
+            }), 128 /* KEYED_FRAGMENT */))
+          ])
+        ]))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__v_model_on_component_with_ref_binding_should_not_duplicate_value.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_model_on_component_with_ref_binding_should_not_duplicate_value.snap
@@ -6,8 +6,8 @@ expression: ts_output
 import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-import { ref } from 'vue';
-import MyInput from './MyInput.vue';
+import { ref } from 'vue'
+import MyInput from './MyInput.vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
@@ -16,7 +16,10 @@ export default /*@__PURE__*/_defineComponent({
 const message = ref('hello');
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(MyInput, { modelValue: message.value, "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((message).value = $event)) }, null, 8 /* PROPS */, ["modelValue"]))
+  return (_openBlock(), _createBlock(MyInput, {
+      modelValue: message.value,
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((message).value = $event))
+    }, null, 8 /* PROPS */, ["modelValue"]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__v_model_with_named_prop_on_component_with_ref_binding.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_model_with_named_prop_on_component_with_ref_binding.snap
@@ -6,8 +6,8 @@ expression: ts_output
 import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-import { ref } from 'vue';
-import MyEditor from './MyEditor.vue';
+import { ref } from 'vue'
+import MyEditor from './MyEditor.vue'
 
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
@@ -17,7 +17,12 @@ const content = ref('');
 const title = ref('Untitled');
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createBlock(MyEditor, { modelValue: content.value, "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((content).value = $event)), title: title.value, "onUpdate:title": _cache[1] || (_cache[1] = ($event: any) => ((title).value = $event)) }, null, 8 /* PROPS */, ["modelValue", "title"]))
+  return (_openBlock(), _createBlock(MyEditor, {
+      modelValue: content.value,
+      "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((content).value = $event)),
+      title: title.value,
+      "onUpdate:title": _cache[1] || (_cache[1] = ($event: any) => ((title).value = $event))
+    }, null, 8 /* PROPS */, ["modelValue", "title"]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__withdefaults_with_function_default.snap
+++ b/tests/snapshots/sfc/ts/script_setup__withdefaults_with_function_default.snap
@@ -19,7 +19,9 @@ export default /*@__PURE__*/_defineComponent({
 
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => { return (_openBlock(), _createElementBlock("div", { key: item }, _toDisplayString(item), 1 /* TEXT */)) }), 128 /* KEYED_FRAGMENT */))
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(__props.items, (item) => {
+      return (_openBlock(), _createElementBlock("div", { key: item }, _toDisplayString(item), 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
 }
 }
 


### PR DESCRIPTION
## Summary

Fixes 38 bugs discovered during large-scale Vue 3 project validation (500+ SFCs).

### Template Codegen (17 fixes)
- Hoisted VNode helpers missing from preamble imports
- Static string escaping, property key quoting, ES6 shorthand ref/unref
- Line comments corrupting generated code, v-slot in props, custom directives in v-if
- TypeScript `as` cast removal, whitespace slots, kebab-case built-ins
- Built-in component resolution in v-if/v-for, hyphenated names, ref hoisting
- Whitespace root text nodes, scope_id on component VNodes
- **v-show on component elements not generating `_withDirectives` (Bug-37)**
- **`mergeProps` path dropping static `class`/`style` when combined with dynamic bindings (Bug-38)**

### Script Compilation (9 fixes)
- Side-effect imports, multiline destructuring, `declare global`
- `type` variable detection, `export type` re-exports, duplicate imports
- Top-level await in inline mode, default+type-only imports, ref unwrap for destructured composables

### Template Extraction (3 fixes)
- String literal `}` truncating render, brace depth tracking, template-only SFC export

### Vite Plugin (9 fixes)
- node_modules .vue handling, directory index resolution, alias fallback
- OXC error handling, vite:vue shim, virtual module prefix, `__x00__` URL leak
- Dynamic import warnings, Vue 3 feature flags

## Test plan
- [x] All existing tests pass (0 failures across full test suite)
- [x] Added unit tests for: ref hoisting prevention, scope_id component exclusion, kebab-case builtins
- [x] Added SFC snapshot tests for: v-if/v-for built-in components, hyphenated component names, scope_id exclusion
- [x] Added vdom fixture tests for kebab-case built-in component variants
- [x] Added DOM snapshot tests for: v-show on child/root components, mergeProps with static class/style (Bug-37, Bug-38)
- [x] Updated all affected snapshots (JS and TS modes)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)