### PR TITLE
fix: add vite8 compiler compatibility regressions

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -286,6 +286,134 @@ mod tests {
     }
 
     #[test]
+    fn test_patch_flag_dynamic_style_and_class_without_bindings() {
+        use crate::codegen::patch_flag::calculate_element_patch_info;
+        use crate::parser::parse;
+
+        let allocator = bumpalo::Bump::new();
+        let (root, errors) = parse(
+            &allocator,
+            r#"<div><div :style="knobStyle" :class="{ dragging }"></div></div>"#,
+        );
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        let inner = match &root.children[0] {
+            crate::ast::TemplateChildNode::Element(el) => match &el.children[0] {
+                crate::ast::TemplateChildNode::Element(inner) => inner,
+                other => panic!("expected inner element, got {:?}", other.node_type()),
+            },
+            other => panic!("expected root element, got {:?}", other.node_type()),
+        };
+
+        let (flag, dynamic_props) = calculate_element_patch_info(inner, None, false);
+        assert_eq!(flag, Some(6), "expected CLASS|STYLE patch flag");
+        assert_eq!(dynamic_props, None, "class/style should not produce dynamic prop list");
+    }
+
+    #[test]
+    fn test_patch_flag_dynamic_style_and_class_after_transform_with_prefix_identifiers() {
+        use crate::codegen::patch_flag::calculate_element_patch_info;
+        use crate::options::TransformOptions;
+        use crate::parser::parse;
+        use crate::transform::transform;
+
+        let allocator = bumpalo::Bump::new();
+        let (mut root, errors) = parse(
+            &allocator,
+            r#"<div class="map"><div :style="knobStyle" :class="{ dragging }"></div></div>"#,
+        );
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        transform(
+            &allocator,
+            &mut root,
+            TransformOptions {
+                prefix_identifiers: true,
+                hoist_static: true,
+                ..Default::default()
+            },
+            None,
+        );
+
+        let inner = match &root.children[0] {
+            crate::ast::TemplateChildNode::Element(el) => match &el.children[0] {
+                crate::ast::TemplateChildNode::Element(inner) => inner,
+                other => panic!("expected inner element, got {:?}", other.node_type()),
+            },
+            other => panic!("expected root element, got {:?}", other.node_type()),
+        };
+
+        let (flag, dynamic_props) = calculate_element_patch_info(inner, None, false);
+        assert_eq!(
+            flag,
+            Some(6),
+            "expected CLASS|STYLE patch flag after transform, props: {:?}",
+            inner.props
+        );
+        assert_eq!(dynamic_props, None, "class/style should not produce dynamic prop list");
+    }
+
+    #[test]
+    fn test_patch_flag_dynamic_style_for_setup_ref_member_access_after_transform() {
+        use crate::codegen::patch_flag::calculate_element_patch_info;
+        use crate::options::{BindingMetadata, BindingType, TransformOptions};
+        use crate::parser::parse;
+        use crate::transform::transform;
+        use vize_carton::FxHashMap;
+
+        let allocator = bumpalo::Bump::new();
+        let (mut root, errors) = parse(
+            &allocator,
+            r#"<div><div :style="floatingStyles.value"></div></div>"#,
+        );
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        transform(
+            &allocator,
+            &mut root,
+            TransformOptions {
+                prefix_identifiers: true,
+                hoist_static: true,
+                ..Default::default()
+            },
+            None,
+        );
+
+        let inner = match &root.children[0] {
+            crate::ast::TemplateChildNode::Element(el) => match &el.children[0] {
+                crate::ast::TemplateChildNode::Element(inner) => inner,
+                other => panic!("expected inner element, got {:?}", other.node_type()),
+            },
+            other => panic!("expected root element, got {:?}", other.node_type()),
+        };
+
+        let mut bindings = FxHashMap::default();
+        bindings.insert("floatingStyles".into(), BindingType::SetupRef);
+        let binding_metadata = BindingMetadata {
+            bindings,
+            props_aliases: FxHashMap::default(),
+            is_script_setup: true,
+        };
+
+        let (flag_with_binding, dynamic_props_with_binding) = calculate_element_patch_info(
+            inner,
+            Some(&binding_metadata),
+            false,
+        );
+        assert_eq!(
+            flag_with_binding,
+            Some(4),
+            "expected STYLE patch flag with setup ref binding metadata, props: {:?}",
+            inner.props
+        );
+        assert_eq!(
+            dynamic_props_with_binding,
+            None,
+            "style should not produce dynamic prop list with bindings"
+        );
+    }
+
+    #[test]
     fn test_codegen_preamble_module() {
         use crate::options::CodegenMode;
         let options = super::CodegenOptions {
@@ -394,6 +522,23 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_dynamic_slot_outlet_name() {
+        let result = compile!(
+            r#"<div><template v-for="tab in tabs" :key="tab.key"><slot :name="tab.key" :tab="tab" /></template></div>"#
+        );
+        assert!(
+            result.code.contains("_renderSlot(_ctx.$slots, tab.key, {tab: tab})"),
+            "dynamic slot outlet should use the dynamic slot name expression:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("{ name: tab.key"),
+            "dynamic slot outlet should not leak `name` into slot props:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_codegen_conditional_slot_with_else_does_not_append_undefined() {
         let result = compile!(
             r#"<MyDialog>
@@ -490,6 +635,26 @@ mod tests {
                 .code
                 .contains("[_toDisplayString(speaker.affiliation),"),
             "expected v-if branch children array to avoid raw string entries. Got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_codegen_v_for_template_else_interpolation_wraps_text_vnode() {
+        let result = compile!(
+            r#"<p><template v-for="(seg, i) in splitByQuery(name)" :key="i"><mark v-if="seg.match">{{ seg.text }}</mark><template v-else>{{ seg.text }}</template></template></p>"#
+        );
+
+        assert!(
+            result
+                .code
+                .contains("_createTextVNode(_toDisplayString(seg.text), 1 /* TEXT */)"),
+            "expected v-for template else interpolation to be wrapped in createTextVNode. Got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("[_toDisplayString(seg.text)]"),
+            "expected v-for template else interpolation to avoid raw string fragment children. Got:\n{}",
             result.code
         );
     }

--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -233,10 +233,14 @@ pub fn generate_comment(ctx: &mut CodegenContext, comment: &CommentNode) {
 
 /// Generate interpolation
 pub fn generate_interpolation(ctx: &mut CodegenContext, interp: &InterpolationNode<'_>) {
+    let create_text = ctx.helper(RuntimeHelper::CreateText);
     let helper = ctx.helper(RuntimeHelper::ToDisplayString);
+    ctx.use_helper(RuntimeHelper::CreateText);
     ctx.use_helper(RuntimeHelper::ToDisplayString);
+    ctx.push(create_text);
+    ctx.push("(");
     ctx.push(helper);
     ctx.push("(");
     generate_expression(ctx, &interp.content);
-    ctx.push(")");
+    ctx.push("), 1 /* TEXT */)");
 }

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -31,9 +31,10 @@ pub struct CodegenContext {
     pub(super) used_helpers: FxHashSet<RuntimeHelper>,
     /// Cache index for v-once
     pub(super) cache_index: usize,
-    /// Template-scope parameters (slot props and v-for aliases) that should
-    /// not be prefixed with `_ctx.`
+    /// Slot parameters (identifiers that should not be prefixed with _ctx.)
     pub(super) slot_params: FxHashSet<String>,
+    /// Depth counter for slot render generation scope.
+    pub(super) slot_render_depth: u32,
     /// When true, skip `is` prop in generate_props (used for dynamic components)
     pub(super) skip_is_prop: bool,
     /// When true, skip scope_id attribute in props (used for component/slot elements)
@@ -71,6 +72,7 @@ impl CodegenContext {
             used_helpers: FxHashSet::default(),
             cache_index: 0,
             slot_params: FxHashSet::default(),
+            slot_render_depth: 0,
             skip_is_prop: false,
             skip_scope_id: false,
             skip_normalize: false,
@@ -79,36 +81,56 @@ impl CodegenContext {
         }
     }
 
-    /// Add template-scope parameters (identifiers that should not be prefixed)
+    /// Add slot parameters (identifiers that should not be prefixed)
     pub fn add_slot_params(&mut self, params: &[String]) {
         for param in params {
             self.slot_params.insert(param.clone());
         }
     }
 
-    /// Remove template-scope parameters when exiting their scope
+    /// Remove slot parameters (when exiting slot scope)
     pub fn remove_slot_params(&mut self, params: &[String]) {
         for param in params {
             self.slot_params.remove(param);
         }
     }
 
-    /// Check if an identifier is a template-scope parameter
+    /// Check if an identifier is a slot parameter
     pub fn is_slot_param(&self, name: &str) -> bool {
         self.slot_params.contains(name)
     }
 
-    /// Check if there are any template-scope parameters registered
+    /// Check if there are any slot parameters registered (fast path check)
     #[inline]
     pub fn has_slot_params(&self) -> bool {
         !self.slot_params.is_empty()
     }
 
-    /// Event handler caching is unsafe while template-scope params are in play,
-    /// because a cached closure would capture the first scoped value.
+    /// Event handler caching is unsafe while scoped params or slot render content
+    /// are in play, because a cached closure would capture the first scoped value.
     #[inline]
     pub fn cache_handlers_in_current_scope(&self) -> bool {
-        self.options.cache_handlers && !self.has_slot_params()
+        self.options.cache_handlers && !self.has_slot_params() && !self.in_slot_render()
+    }
+
+    /// Enter slot render generation scope.
+    #[inline]
+    pub fn enter_slot_render(&mut self) {
+        self.slot_render_depth += 1;
+    }
+
+    /// Exit slot render generation scope.
+    #[inline]
+    pub fn exit_slot_render(&mut self) {
+        if self.slot_render_depth > 0 {
+            self.slot_render_depth -= 1;
+        }
+    }
+
+    /// Returns true when currently generating slot render content.
+    #[inline]
+    pub fn in_slot_render(&self) -> bool {
+        self.slot_render_depth > 0
     }
 
     /// Get next cache index for v-once

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -19,7 +19,10 @@ use super::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
         props::generate_props,
-        slots::{generate_slots, has_dynamic_slots_flag, has_slot_children},
+        slots::{
+            generate_slot_outlet_name, generate_slot_outlet_props_entries, generate_slots,
+            has_dynamic_slots_flag, has_slot_children, has_slot_outlet_props,
+        },
     },
     directives::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
@@ -90,25 +93,17 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         ctx.use_helper(RuntimeHelper::RenderSlot);
         ctx.push(helper);
         ctx.push("(_ctx.$slots, ");
-
-        // Get slot name from props
-        let slot_name = el
-            .props
-            .iter()
-            .find_map(|p| match p {
-                PropNode::Attribute(attr) if attr.name == "name" => {
-                    attr.value.as_ref().map(|v| v.content.as_str())
-                }
-                _ => None,
-            })
-            .unwrap_or("default");
-        ctx.push("\"");
-        ctx.push(slot_name);
-        ctx.push("\"");
+        generate_slot_outlet_name(ctx, el);
 
         // Generate fallback content if present
         if !el.children.is_empty() {
-            ctx.push(", {}, () => [");
+            if has_slot_outlet_props(el) {
+                ctx.push(", {");
+                generate_slot_outlet_props_entries(ctx, el);
+                ctx.push("}, () => [");
+            } else {
+                ctx.push(", {}, () => [");
+            }
             ctx.indent();
             let filtered: Vec<_> = el
                 .children
@@ -125,6 +120,10 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.deindent();
             ctx.newline();
             ctx.push("])");
+        } else if has_slot_outlet_props(el) {
+            ctx.push(", {");
+            generate_slot_outlet_props_entries(ctx, el);
+            ctx.push("})");
         } else {
             ctx.push(")");
         }
@@ -461,25 +460,19 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.use_helper(RuntimeHelper::RenderSlot);
             ctx.push(helper);
             ctx.push("(_ctx.$slots, ");
-
-            // Get slot name from props
-            let slot_name = el
-                .props
-                .iter()
-                .find_map(|p| match p {
-                    PropNode::Attribute(attr) if attr.name == "name" => {
-                        attr.value.as_ref().map(|v| v.content.as_str())
-                    }
-                    _ => None,
-                })
-                .unwrap_or("default");
-            ctx.push("\"");
-            ctx.push(slot_name);
-            ctx.push("\"");
+            generate_slot_outlet_name(ctx, el);
+            let has_slot_props = has_slot_outlet_props(el);
 
             // Generate fallback content if present
             if !el.children.is_empty() {
-                ctx.push(", {}, () => [");
+                if !has_slot_props {
+                    ctx.push(", {}");
+                } else {
+                    ctx.push(", {");
+                    generate_slot_outlet_props_entries(ctx, el);
+                    ctx.push("}");
+                }
+                ctx.push(", () => [");
                 ctx.indent();
                 let filtered: Vec<_> = el
                     .children
@@ -496,6 +489,10 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.deindent();
                 ctx.newline();
                 ctx.push("])");
+            } else if has_slot_props {
+                ctx.push(", {");
+                generate_slot_outlet_props_entries(ctx, el);
+                ctx.push("})");
             } else {
                 ctx.push(")");
             }

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -19,7 +19,10 @@ use super::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
         props::generate_props,
-        slots::{generate_slots, has_dynamic_slots_flag, has_slot_children},
+        slots::{
+            generate_slot_outlet_name, generate_slot_outlet_props_entries, generate_slots,
+            has_dynamic_slots_flag, has_slot_children, has_slot_outlet_props,
+        },
     },
     directives::{generate_vmodel_closing, generate_vshow_closing},
     helpers::{
@@ -343,30 +346,8 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.use_helper(RuntimeHelper::RenderSlot);
             ctx.push(helper);
             ctx.push("(_ctx.$slots, ");
-            // Get slot name from props
-            let slot_name = el
-                .props
-                .iter()
-                .find_map(|p| match p {
-                    PropNode::Attribute(attr) if attr.name == "name" => {
-                        attr.value.as_ref().map(|v| v.content.as_str())
-                    }
-                    _ => None,
-                })
-                .unwrap_or("default");
-            ctx.push("\"");
-            ctx.push(slot_name);
-            ctx.push("\"");
-
-            // Generate slot props (excluding 'name' attribute)
-            let slot_props: Vec<_> = el
-                .props
-                .iter()
-                .filter(|p| match p {
-                    PropNode::Attribute(attr) => attr.name != "name",
-                    PropNode::Directive(_) => true,
-                })
-                .collect();
+            generate_slot_outlet_name(ctx, el);
+            let has_slot_props = has_slot_outlet_props(el);
 
             // Generate fallback content if present
             // Slots: skip scope_id in props -- not a real rendered element
@@ -374,11 +355,12 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.skip_scope_id = true;
             if !el.children.is_empty() {
                 // If we have children but no props, pass empty object
-                if slot_props.is_empty() {
+                if !has_slot_props {
                     ctx.push(", {}");
                 } else {
-                    ctx.push(", ");
-                    generate_props(ctx, &el.props);
+                    ctx.push(", {");
+                    generate_slot_outlet_props_entries(ctx, el);
+                    ctx.push("}");
                 }
                 ctx.push(", () => [");
                 ctx.skip_scope_id = prev_skip_scope_id;
@@ -398,10 +380,11 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.deindent();
                 ctx.newline();
                 ctx.push("])");
-            } else if !slot_props.is_empty() {
-                ctx.push(", ");
-                generate_props(ctx, &el.props);
+            } else if has_slot_props {
+                ctx.push(", {");
+                generate_slot_outlet_props_entries(ctx, el);
                 ctx.skip_scope_id = prev_skip_scope_id;
+                ctx.push("}");
                 ctx.push(")");
             } else {
                 ctx.skip_scope_id = prev_skip_scope_id;

--- a/crates/vize_atelier_core/src/codegen/expression/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/generate.rs
@@ -19,20 +19,10 @@ pub fn generate_simple_expression_with_prefix(ctx: &CodegenContext, content: &st
     prefix_identifiers_with_context(content, ctx)
 }
 
-/// Check if a string is a simple member expression like `_ctx.foo` or `$setup.bar`.
-/// This is used to determine if an event handler needs wrapping.
+/// Check if a string is a member-expression style handler reference.
+/// This includes forms like `_ctx.foo`, `$setup.bar`, and `_unref(store).save`.
 pub fn is_simple_member_expression(s: &str) -> bool {
-    if let Some(dot_pos) = s.find('.') {
-        let prefix = &s[..dot_pos];
-        let suffix = &s[dot_pos + 1..];
-        let valid_prefix = prefix == "_ctx" || prefix == "$setup" || prefix == "$props";
-        let valid_suffix = !suffix.is_empty()
-            && !suffix.contains('.')
-            && !suffix.contains('(')
-            && !suffix.contains('[');
-        return valid_prefix && valid_suffix;
-    }
-    false
+    crate::transforms::is_event_handler_reference_expression(s)
 }
 
 /// Check if an event handler expression is an inline handler.
@@ -156,7 +146,7 @@ pub fn generate_event_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::generate_simple_expression_with_prefix;
+    use super::{generate_simple_expression_with_prefix, is_simple_member_expression};
     use crate::ast::{SimpleExpressionNode, SourceLocation};
     use crate::codegen::context::CodegenContext;
     use crate::codegen::expression::generate_simple_expression;
@@ -279,6 +269,14 @@ mod tests {
             !output.contains("Line 1\nLine 2"),
             "Expected raw newline to be escaped. Got: {}",
             output
+        );
+    }
+
+    #[test]
+    fn test_unreffed_member_expression_is_handler_reference() {
+        assert!(
+            is_simple_member_expression("_unref(actionHandler).selectItem"),
+            "unref() member expressions should be treated as direct handler references"
         );
     }
 }

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -355,9 +355,21 @@ pub fn is_constant_simple_expression(
         return true;
     }
 
+    // Expressions that already reference runtime instance/setup/props context are never
+    // compile-time constants. Returning false here is conservative and prevents
+    // transformed bindings like `_ctx.foo` from incorrectly dropping patch flags.
+    let content = exp.content.as_str();
+    if content.contains("_ctx.")
+        || content.contains("$setup.")
+        || content.contains("__props.")
+        || content.contains("$props.")
+    {
+        return false;
+    }
+
     let mut wrapped = String::with_capacity(exp.content.len() + 2);
     wrapped.push('(');
-    wrapped.push_str(exp.content.as_str());
+    wrapped.push_str(content);
     wrapped.push(')');
 
     let allocator = oxc_allocator::Allocator::default();

--- a/crates/vize_atelier_core/src/codegen/root.rs
+++ b/crates/vize_atelier_core/src/codegen/root.rs
@@ -7,11 +7,20 @@ use crate::ast::{RootNode, RuntimeHelper, TemplateChildNode};
 
 use super::context::CodegenContext;
 use super::element::helpers::is_dynamic_component_tag;
-use vize_carton::String;
+use vize_carton::{camelize, capitalize, String};
 
 /// Check if a root-level text node is ignorable whitespace.
 pub(super) fn is_ignorable_root_text(child: &TemplateChildNode<'_>) -> bool {
     matches!(child, TemplateChildNode::Text(text) if text.content.chars().all(|c| c.is_whitespace()))
+}
+
+fn imported_directive_binding_name(name: &str) -> String {
+    let camel = camelize(name);
+    let pascal = capitalize(&camel);
+    let mut binding = String::with_capacity(1 + pascal.len());
+    binding.push('v');
+    binding.push_str(&pascal);
+    binding
 }
 
 /// Generate preamble from a list of helpers.
@@ -125,14 +134,24 @@ pub(super) fn generate_assets(ctx: &mut CodegenContext, root: &RootNode<'_>) {
 
     // Resolve directives
     for directive in root.directives.iter() {
-        ctx.use_helper(RuntimeHelper::ResolveDirective);
         ctx.push("const _directive_");
         ctx.push(&directive.replace('-', "_"));
         ctx.push(" = ");
-        ctx.push(ctx.helper(RuntimeHelper::ResolveDirective));
-        ctx.push("(\"");
-        ctx.push(directive);
-        ctx.push("\")");
+        let binding_name = imported_directive_binding_name(directive);
+        let uses_imported_binding = ctx
+            .options
+            .binding_metadata
+            .as_ref()
+            .is_some_and(|m| m.bindings.contains_key(binding_name.as_str()));
+        if uses_imported_binding {
+            ctx.push(&binding_name);
+        } else {
+            ctx.use_helper(RuntimeHelper::ResolveDirective);
+            ctx.push(ctx.helper(RuntimeHelper::ResolveDirective));
+            ctx.push("(\"");
+            ctx.push(directive);
+            ctx.push("\")");
+        }
         ctx.newline();
         has_resolved_assets = true;
     }

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -9,8 +9,14 @@ use super::context::CodegenContext;
 use super::expression::generate_expression;
 use super::helpers::{escape_js_string, is_valid_js_identifier};
 use super::node::generate_node;
+use super::props::{generate_directive_prop_with_static, is_supported_directive};
 use vize_carton::String;
 use vize_carton::ToCompactString;
+
+pub(crate) enum SlotOutletName<'a> {
+    Static(String),
+    Dynamic(&'a ExpressionNode<'a>),
+}
 
 /// Get slot props expression as raw source (not transformed)
 fn get_slot_props(dir: &DirectiveNode<'_>) -> Option<vize_carton::String> {
@@ -82,6 +88,158 @@ fn extract_slot_params(props_str: &str) -> Vec<String> {
     params
 }
 
+fn is_slot_name_bind(dir: &DirectiveNode<'_>) -> bool {
+    if dir.name.as_str() != "bind" {
+        return false;
+    }
+
+    match dir.arg.as_ref() {
+        Some(ExpressionNode::Simple(exp)) => exp.is_static && exp.content.as_str() == "name",
+        _ => false,
+    }
+}
+
+fn is_slot_name_prop(prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attr) => attr.name.as_str() == "name",
+        PropNode::Directive(dir) => is_slot_name_bind(dir),
+    }
+}
+
+pub(crate) fn get_slot_outlet_name<'a>(el: &'a ElementNode<'a>) -> SlotOutletName<'a> {
+    for prop in &el.props {
+        match prop {
+            PropNode::Attribute(attr) if attr.name.as_str() == "name" => {
+                let name = attr
+                    .value
+                    .as_ref()
+                    .map(|v| v.content.clone())
+                    .unwrap_or_else(|| String::new("default"));
+                return SlotOutletName::Static(name);
+            }
+            PropNode::Directive(dir) if is_slot_name_bind(dir) => {
+                if let Some(exp) = dir.exp.as_ref() {
+                    return SlotOutletName::Dynamic(exp);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    SlotOutletName::Static(String::new("default"))
+}
+
+pub(crate) fn generate_slot_outlet_name(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    match get_slot_outlet_name(el) {
+        SlotOutletName::Static(name) => {
+            ctx.push("\"");
+            ctx.push(&escape_js_string(name.as_str()));
+            ctx.push("\"");
+        }
+        SlotOutletName::Dynamic(exp) => generate_expression(ctx, exp),
+    }
+}
+
+pub(crate) fn has_slot_outlet_props(el: &ElementNode<'_>) -> bool {
+    el.props.iter().any(|prop| !is_slot_name_prop(prop))
+}
+
+pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    let filtered: Vec<_> = el
+        .props
+        .iter()
+        .filter(|prop| !is_slot_name_prop(prop))
+        .collect();
+
+    let static_class = filtered.iter().find_map(|prop| {
+        if let PropNode::Attribute(attr) = prop {
+            if attr.name.as_str() == "class" {
+                return attr.value.as_ref().map(|v| v.content.as_str());
+            }
+        }
+        None
+    });
+
+    let static_style = filtered.iter().find_map(|prop| {
+        if let PropNode::Attribute(attr) = prop {
+            if attr.name.as_str() == "style" {
+                return attr.value.as_ref().map(|v| v.content.as_str());
+            }
+        }
+        None
+    });
+
+    let has_dynamic_class = filtered.iter().any(|prop| {
+        if let PropNode::Directive(dir) = prop {
+            if dir.name.as_str() == "bind" {
+                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
+                    return exp.is_static && exp.content.as_str() == "class";
+                }
+            }
+        }
+        false
+    });
+
+    let has_dynamic_style = filtered.iter().any(|prop| {
+        if let PropNode::Directive(dir) = prop {
+            if dir.name.as_str() == "bind" {
+                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
+                    return exp.is_static && exp.content.as_str() == "style";
+                }
+            }
+        }
+        false
+    });
+
+    let mut first = true;
+
+    for prop in filtered {
+        match prop {
+            PropNode::Attribute(attr) => {
+                if (attr.name.as_str() == "class" && has_dynamic_class)
+                    || (attr.name.as_str() == "style" && has_dynamic_style)
+                {
+                    continue;
+                }
+
+                if !first {
+                    ctx.push(", ");
+                }
+
+                if is_valid_js_identifier(&attr.name) {
+                    ctx.push(&attr.name);
+                } else {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(&attr.name));
+                    ctx.push("\"");
+                }
+                ctx.push(": ");
+                if let Some(value) = &attr.value {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(value.content.as_str()));
+                    ctx.push("\"");
+                } else {
+                    ctx.push("\"\"");
+                }
+
+                first = false;
+            }
+            PropNode::Directive(dir) => {
+                if !is_supported_directive(dir) || (dir.name.as_str() == "bind" && dir.arg.is_none())
+                {
+                    continue;
+                }
+
+                if !first {
+                    ctx.push(", ");
+                }
+                generate_directive_prop_with_static(ctx, dir, static_class, static_style);
+                first = false;
+            }
+        }
+    }
+}
+
 /// Check if component has slot children that need to be generated as slots object
 pub fn has_slot_children(el: &ElementNode<'_>) -> bool {
     if el.children.is_empty() {
@@ -127,48 +285,8 @@ pub fn has_dynamic_slots_flag(el: &ElementNode<'_>) -> bool {
     if collected_slots.iter().any(|s| s.is_dynamic) {
         return true;
     }
-    if has_forwarded_slot_outlet(el) {
-        return true;
-    }
-    if has_dynamic_default_slot_children(el) {
-        return true;
-    }
     // Also check for v-if/v-for on slot templates (they become IfNode/ForNode children)
     has_conditional_or_loop_slots(el)
-}
-
-/// Check if the implicit default slot contains structural nodes that depend on
-/// parent state and therefore must force slot updates.
-fn has_dynamic_default_slot_children(el: &ElementNode<'_>) -> bool {
-    el.children
-        .iter()
-        .any(|child| matches!(child, TemplateChildNode::If(_) | TemplateChildNode::For(_)))
-}
-
-/// Check whether this component forwards an incoming slot to another component,
-/// e.g. `<Inner><slot /></Inner>`.
-fn has_forwarded_slot_outlet(el: &ElementNode<'_>) -> bool {
-    el.children.iter().any(child_contains_slot_outlet)
-}
-
-fn child_contains_slot_outlet(child: &TemplateChildNode<'_>) -> bool {
-    match child {
-        TemplateChildNode::Element(el) => {
-            if el.tag_type == ElementType::Slot || el.tag.as_str() == "slot" {
-                return true;
-            }
-            el.children.iter().any(child_contains_slot_outlet)
-        }
-        TemplateChildNode::If(if_node) => if_node
-            .branches
-            .iter()
-            .flat_map(|branch| branch.children.iter())
-            .any(child_contains_slot_outlet),
-        TemplateChildNode::For(for_node) => {
-            for_node.children.iter().any(child_contains_slot_outlet)
-        }
-        _ => false,
-    }
 }
 
 /// Check if children have conditional (v-if) or looped (v-for) slot templates.
@@ -195,6 +313,34 @@ fn has_conditional_or_loop_slots(el: &ElementNode<'_>) -> bool {
     })
 }
 
+fn child_contains_slot_forwarding(node: &TemplateChildNode<'_>) -> bool {
+    match node {
+        TemplateChildNode::Element(el) => {
+            if el.tag.as_str() == "slot" {
+                return true;
+            }
+            el.children.iter().any(child_contains_slot_forwarding)
+        }
+        TemplateChildNode::If(if_node) => if_node
+            .branches
+            .iter()
+            .any(|branch| branch.children.iter().any(child_contains_slot_forwarding)),
+        TemplateChildNode::IfBranch(branch) => branch
+            .children
+            .iter()
+            .any(child_contains_slot_forwarding),
+        TemplateChildNode::For(for_node) => for_node
+            .children
+            .iter()
+            .any(child_contains_slot_forwarding),
+        _ => false,
+    }
+}
+
+fn has_forwarded_slots(el: &ElementNode<'_>) -> bool {
+    el.children.iter().any(child_contains_slot_forwarding)
+}
+
 /// Generate slots object for component
 pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     // Note: WithCtx helper is registered at each _withCtx() output site,
@@ -211,12 +357,9 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     });
 
     let collected_slots = collect_slots(el);
-    let has_forwarded_slots = has_forwarded_slot_outlet(el);
-    let has_dynamic_slots = ctx.in_v_for
-        || collected_slots.iter().any(|s| s.is_dynamic)
-        || has_forwarded_slots
-        || has_dynamic_default_slot_children(el);
+    let has_dynamic_slots = ctx.in_v_for || collected_slots.iter().any(|s| s.is_dynamic);
     let has_conditional_slots = has_conditional_or_loop_slots(el);
+    let has_forwarded_slots = has_forwarded_slots(el);
 
     // If there are conditional (v-if) or looped (v-for) slots, use createSlots
     if has_conditional_slots && root_slot.is_none() {
@@ -251,7 +394,9 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
         ctx.push(" => [");
         ctx.indent();
+        ctx.enter_slot_render();
         generate_slot_children(ctx, &el.children);
+        ctx.exit_slot_render();
         ctx.deindent();
         ctx.newline();
         ctx.push("])");
@@ -340,7 +485,9 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
                         ctx.push(" => [");
                         ctx.indent();
+                        ctx.enter_slot_render();
                         generate_slot_children(ctx, &template_el.children);
+                        ctx.exit_slot_render();
                         ctx.deindent();
                         ctx.newline();
                         ctx.push("])");
@@ -352,16 +499,20 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             }
         }
 
-        // Generate default slot for non-template children
+        // Generate default slot for non-template children.
+        // Filter out whitespace-only text nodes and comments — these are not
+        // meaningful in component slot context and would cause issues like
+        // `<Transition>` receiving multiple children from surrounding spaces.
         let default_children: Vec<_> = el
             .children
             .iter()
-            .filter(|child| {
-                if let TemplateChildNode::Element(template_el) = child {
+            .filter(|child| match child {
+                TemplateChildNode::Element(template_el) => {
                     !(template_el.tag.as_str() == "template" && has_v_slot(template_el))
-                } else {
-                    true
                 }
+                TemplateChildNode::Text(t) => !t.content.trim().is_empty(),
+                TemplateChildNode::Comment(_) => false,
+                _ => true,
             })
             .collect();
 
@@ -375,6 +526,7 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.push(ctx.helper(RuntimeHelper::WithCtx));
             ctx.push("(() => [");
             ctx.indent();
+            ctx.enter_slot_render();
             for (i, child) in default_children.iter().enumerate() {
                 if i > 0 {
                     ctx.push(",");
@@ -382,6 +534,7 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.newline();
                 generate_slot_child_node(ctx, child);
             }
+            ctx.exit_slot_render();
             ctx.deindent();
             ctx.newline();
             ctx.push("])");
@@ -391,10 +544,10 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     // Add slot stability flag
     ctx.push(",");
     ctx.newline();
-    if has_forwarded_slots {
-        ctx.push("_: 3 /* FORWARDED */");
-    } else if has_dynamic_slots {
+    if has_dynamic_slots {
         ctx.push("_: 2 /* DYNAMIC */");
+    } else if has_forwarded_slots {
+        ctx.push("_: 3 /* FORWARDED */");
     } else {
         ctx.push("_: 1 /* STABLE */");
     }
@@ -633,6 +786,18 @@ fn generate_static_slot_entry(ctx: &mut CodegenContext, template_el: &ElementNod
 
 /// Generate children for a slot
 fn generate_slot_children(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
+    // Filter out whitespace-only text nodes and comments.
+    // These are not meaningful in slot context and cause issues like
+    // `<Transition>` receiving multiple children from surrounding whitespace.
+    let children: Vec<_> = children
+        .iter()
+        .filter(|child| match child {
+            TemplateChildNode::Text(t) => !t.content.trim().is_empty(),
+            TemplateChildNode::Comment(_) => false,
+            _ => true,
+        })
+        .collect();
+
     // Check if all children are text/interpolation - if so, concatenate into single _createTextVNode
     let all_text_or_interp = children.iter().all(|child| {
         matches!(

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -11,12 +11,12 @@ use vize_carton::ToCompactString;
 
 use super::{
     super::{
-        children::{generate_children_force_array, is_directive_comment},
+        children::{generate_children, is_directive_comment},
         context::CodegenContext,
-        element::is_whitespace_or_comment,
         element::{
-            generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
-            has_custom_directives, has_vmodel_directive, has_vshow_directive,
+            generate_custom_directives_closing, generate_vmodel_closing,
+            generate_vshow_closing, has_custom_directives, has_vmodel_directive,
+            has_vshow_directive, is_whitespace_or_comment,
         },
         expression::generate_expression,
         helpers::{escape_js_string, is_builtin_component},
@@ -24,7 +24,10 @@ use super::{
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
-        slots::{generate_slots, has_dynamic_slots_flag, has_slot_children},
+        slots::{
+            generate_slot_outlet_name, generate_slot_outlet_props_entries, generate_slots,
+            has_dynamic_slots_flag, has_slot_children, has_slot_outlet_props,
+        },
     },
     generate::{
         extract_static_class_style, generate_if_branch_props_object, has_dynamic_class,
@@ -65,6 +68,7 @@ pub(super) fn generate_if_branch(
                     // Component
                     generate_if_branch_component(ctx, el, branch, branch_index);
                 } else if el.tag_type == ElementType::Slot {
+                    // Slot outlet
                     generate_if_branch_slot(ctx, el, branch, branch_index);
                 } else {
                     // Regular element
@@ -82,57 +86,6 @@ pub(super) fn generate_if_branch(
     }
 }
 
-/// Generate slot outlet for if branch.
-fn generate_if_branch_slot(
-    ctx: &mut CodegenContext,
-    el: &ElementNode<'_>,
-    branch: &IfBranchNode<'_>,
-    branch_index: usize,
-) {
-    ctx.use_helper(RuntimeHelper::RenderSlot);
-    ctx.push(ctx.helper(RuntimeHelper::RenderSlot));
-    ctx.push("(_ctx.$slots, ");
-
-    let slot_name = el
-        .props
-        .iter()
-        .find_map(|p| match p {
-            PropNode::Attribute(attr) if attr.name == "name" => {
-                attr.value.as_ref().map(|v| v.content.as_str())
-            }
-            _ => None,
-        })
-        .unwrap_or("default");
-    ctx.push("\"");
-    ctx.push(slot_name);
-    ctx.push("\"");
-    ctx.push(", { key: ");
-    generate_if_branch_key(ctx, branch, branch_index);
-    ctx.push(" }");
-
-    if !el.children.is_empty() {
-        ctx.push(", () => [");
-        ctx.indent();
-        let filtered: Vec<_> = el
-            .children
-            .iter()
-            .filter(|c| !is_directive_comment(c))
-            .collect();
-        for (i, child) in filtered.iter().enumerate() {
-            if i > 0 {
-                ctx.push(",");
-            }
-            ctx.newline();
-            generate_node(ctx, child);
-        }
-        ctx.deindent();
-        ctx.newline();
-        ctx.push("])");
-    } else {
-        ctx.push(")");
-    }
-}
-
 /// Generate component for if branch.
 fn generate_if_branch_component(
     ctx: &mut CodegenContext,
@@ -141,20 +94,6 @@ fn generate_if_branch_component(
     branch_index: usize,
 ) {
     let is_dynamic_component = el.tag == "component" || el.tag == "Component";
-    let has_custom_dirs = has_custom_directives(el);
-    if has_custom_dirs {
-        ctx.use_helper(RuntimeHelper::WithDirectives);
-        ctx.use_helper(RuntimeHelper::ResolveDirective);
-        ctx.push(ctx.helper(RuntimeHelper::WithDirectives));
-        ctx.push("(");
-    }
-    let has_vshow = has_vshow_directive(el) && !has_custom_dirs;
-    if has_vshow {
-        ctx.use_helper(RuntimeHelper::WithDirectives);
-        ctx.use_helper(RuntimeHelper::VShow);
-        ctx.push(ctx.helper(RuntimeHelper::WithDirectives));
-        ctx.push("(");
-    }
 
     // Components: skip scope_id in props -- Vue runtime applies it via __scopeId
     let prev_skip_scope_id = ctx.skip_scope_id;
@@ -222,13 +161,13 @@ fn generate_if_branch_component(
         calculate_element_patch_info_skip_is(
             el,
             ctx.options.binding_metadata.as_ref(),
-            ctx.cache_handlers_in_current_scope(),
+            ctx.options.cache_handlers,
         )
     } else {
         calculate_element_patch_info(
             el,
             ctx.options.binding_metadata.as_ref(),
-            ctx.cache_handlers_in_current_scope(),
+            ctx.options.cache_handlers,
         )
     };
 
@@ -369,14 +308,49 @@ fn generate_if_branch_component(
         ctx.push("]");
     }
 
-    ctx.push("))");
+    ctx.push("))")
+}
 
-    if has_custom_dirs {
-        generate_custom_directives_closing(ctx, el);
+/// Generate slot outlet for if branch.
+fn generate_if_branch_slot(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+) {
+    // Slots don't use blocks in branch output; use renderSlot directly.
+    let helper = ctx.helper(RuntimeHelper::RenderSlot);
+    ctx.use_helper(RuntimeHelper::RenderSlot);
+    ctx.push(helper);
+    ctx.push("(_ctx.$slots, ");
+    generate_slot_outlet_name(ctx, el);
+
+    // 3rd arg: slot props with branch key
+    ctx.push(", { key: ");
+    generate_if_branch_key(ctx, branch, branch_index);
+    if has_slot_outlet_props(el) {
+        ctx.push(", ");
+        generate_slot_outlet_props_entries(ctx, el);
     }
-    if has_vshow {
-        generate_vshow_closing(ctx, el);
+    ctx.push("}");
+
+    // Fallback content, if present
+    if !el.children.is_empty() {
+        ctx.push(", () => [");
+        let filtered: Vec<_> = el
+            .children
+            .iter()
+            .filter(|c| !is_directive_comment(c))
+            .collect();
+        for (i, child) in filtered.iter().enumerate() {
+            if i > 0 {
+                ctx.push(",");
+            }
+            generate_node(ctx, child);
+        }
+        ctx.push("]");
     }
+    ctx.push(")");
 }
 
 /// Generate element for if branch.
@@ -386,6 +360,13 @@ fn generate_if_branch_element(
     branch: &IfBranchNode<'_>,
     branch_index: usize,
 ) {
+    let (patch_flag, dynamic_props) = calculate_element_patch_info(
+        el,
+        ctx.options.binding_metadata.as_ref(),
+        ctx.cache_handlers_in_current_scope(),
+    );
+    let has_patch_info = patch_flag.is_some() || dynamic_props.is_some();
+
     let has_custom_dirs = has_custom_directives(el);
     if has_custom_dirs {
         ctx.use_helper(RuntimeHelper::WithDirectives);
@@ -393,12 +374,14 @@ fn generate_if_branch_element(
         ctx.push(ctx.helper(RuntimeHelper::WithDirectives));
         ctx.push("(");
     }
+
     let has_vmodel = has_vmodel_directive(el) && !has_custom_dirs;
     if has_vmodel {
         ctx.use_helper(RuntimeHelper::WithDirectives);
         ctx.push(ctx.helper(RuntimeHelper::WithDirectives));
         ctx.push("(");
     }
+
     let has_vshow = has_vshow_directive(el) && !has_vmodel && !has_custom_dirs;
     if has_vshow {
         ctx.use_helper(RuntimeHelper::WithDirectives);
@@ -507,6 +490,30 @@ fn generate_if_branch_element(
         } else {
             generate_if_branch_children(ctx, &el.children);
         }
+    } else if has_patch_info {
+        ctx.push(", null");
+    }
+
+    if let Some(flag) = patch_flag {
+        ctx.push(", ");
+        ctx.push(&flag.to_compact_string());
+        ctx.push(" /* ");
+        let flag_name = patch_flag_name(flag);
+        ctx.push(&flag_name);
+        ctx.push(" */");
+    }
+
+    if let Some(props) = dynamic_props {
+        ctx.push(", [");
+        for (i, prop) in props.iter().enumerate() {
+            if i > 0 {
+                ctx.push(", ");
+            }
+            ctx.push("\"");
+            ctx.push(prop);
+            ctx.push("\"");
+        }
+        ctx.push("]");
     }
 
     ctx.push("))");
@@ -514,9 +521,11 @@ fn generate_if_branch_element(
     if has_custom_dirs {
         generate_custom_directives_closing(ctx, el);
     }
+
     if has_vmodel {
         generate_vmodel_closing(ctx, el);
     }
+
     if has_vshow {
         generate_vshow_closing(ctx, el);
     }
@@ -531,6 +540,7 @@ fn generate_if_branch_template_fragment(
 ) {
     ctx.use_helper(RuntimeHelper::CreateElementBlock);
     ctx.use_helper(RuntimeHelper::Fragment);
+    ctx.use_helper(RuntimeHelper::CreateElementVNode);
     ctx.push("(");
     ctx.push(ctx.helper(RuntimeHelper::OpenBlock));
     ctx.push("(), ");
@@ -539,9 +549,22 @@ fn generate_if_branch_template_fragment(
     ctx.push(ctx.helper(RuntimeHelper::Fragment));
     ctx.push(", { key: ");
     generate_if_branch_key(ctx, branch, branch_index);
-    ctx.push(" }, ");
-    generate_children_force_array(ctx, children);
-    ctx.push(", 64 /* STABLE_FRAGMENT */))");
+    ctx.push(" }, [");
+    ctx.indent();
+    let filtered: Vec<_> = children
+        .iter()
+        .filter(|c| !is_directive_comment(c))
+        .collect();
+    for (i, child) in filtered.iter().enumerate() {
+        if i > 0 {
+            ctx.push(",");
+        }
+        ctx.newline();
+        generate_node(ctx, child);
+    }
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("], 64 /* STABLE_FRAGMENT */))");
 }
 
 /// Generate fragment wrapper for if branch with multiple children.
@@ -561,7 +584,7 @@ fn generate_if_branch_fragment(
     ctx.push(", { key: ");
     generate_if_branch_key(ctx, branch, branch_index);
     ctx.push(" }, ");
-    generate_children_force_array(ctx, &branch.children);
+    generate_children(ctx, &branch.children);
     ctx.push(", 64 /* STABLE_FRAGMENT */))");
 }
 
@@ -580,10 +603,6 @@ fn generate_if_branch_children(ctx: &mut CodegenContext, children: &[TemplateChi
     });
 
     if has_only_text_or_interpolation {
-        let has_interpolation = children
-            .iter()
-            .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
-
         // Use string concatenation for text/interpolation mix
         for (i, child) in children.iter().enumerate() {
             if i > 0 {
@@ -605,13 +624,23 @@ fn generate_if_branch_children(ctx: &mut CodegenContext, children: &[TemplateChi
                 _ => {}
             }
         }
-
-        if has_interpolation {
-            ctx.push(", 1 /* TEXT */");
-        }
     } else {
-        // Complex branch children need the same text/interpolation grouping as
-        // regular element children to avoid raw string array entries.
-        generate_children_force_array(ctx, children);
+        // Complex children - use array (filter directive comments)
+        let filtered: Vec<_> = children
+            .iter()
+            .filter(|c| !is_directive_comment(c))
+            .collect();
+        ctx.push("[");
+        ctx.indent();
+        for (i, child) in filtered.iter().enumerate() {
+            if i > 0 {
+                ctx.push(",");
+            }
+            ctx.newline();
+            generate_node(ctx, child);
+        }
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("]");
     }
 }

--- a/crates/vize_atelier_core/src/codegen/v_if/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/generate.rs
@@ -109,6 +109,34 @@ pub(super) fn generate_single_prop_for_if(
 ) {
     match prop {
         PropNode::Attribute(attr) => {
+            let ref_binding_type = if attr.name == "ref" && ctx.options.inline {
+                attr.value.as_ref().and_then(|v| {
+                    ctx.options
+                        .binding_metadata
+                        .as_ref()
+                        .and_then(|m| m.bindings.get(v.content.as_str()).copied())
+                })
+            } else {
+                None
+            };
+            let needs_ref_key = matches!(
+                ref_binding_type,
+                Some(
+                    crate::options::BindingType::SetupLet
+                        | crate::options::BindingType::SetupRef
+                        | crate::options::BindingType::SetupMaybeRef
+                )
+            );
+
+            if needs_ref_key {
+                let ref_name = &attr.value.as_ref().unwrap().content;
+                ctx.push("ref_key: \"");
+                ctx.push(ref_name);
+                ctx.push("\", ref: ");
+                ctx.push(ref_name);
+                return;
+            }
+
             let needs_quotes = !is_valid_js_identifier(&attr.name);
             if needs_quotes {
                 ctx.push("\"");
@@ -119,9 +147,13 @@ pub(super) fn generate_single_prop_for_if(
             }
             ctx.push(": ");
             if let Some(value) = &attr.value {
-                ctx.push("\"");
-                ctx.push(&escape_js_string(value.content.as_str()));
-                ctx.push("\"");
+                if ref_binding_type.is_some() {
+                    ctx.push(&value.content);
+                } else {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(value.content.as_str()));
+                    ctx.push("\"");
+                }
             } else {
                 ctx.push("\"\"");
             }

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -1,6 +1,6 @@
 //! Element transformation functions.
 
-use vize_carton::{is_builtin_directive, Box, String, Vec};
+use vize_carton::{camelize, capitalize, is_builtin_directive, Box, String, Vec};
 
 use crate::ast::*;
 use crate::transforms::transform_expression::process_inline_handler;
@@ -9,6 +9,15 @@ use super::{ExitFn, TransformContext};
 
 fn is_dynamic_component_tag(tag: &str) -> bool {
     matches!(tag, "component" | "Component")
+}
+
+fn imported_directive_binding_name(name: &str) -> String {
+    let camel = camelize(name);
+    let pascal = capitalize(&camel);
+    let mut binding = String::with_capacity(1 + pascal.len());
+    binding.push('v');
+    binding.push_str(&pascal);
+    binding
 }
 
 /// Transform element node
@@ -142,7 +151,10 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
                 // Handle custom directives - register them for resolveDirective
                 _ if !is_builtin_directive(&dir.name) => {
                     ctx.helper(RuntimeHelper::WithDirectives);
-                    ctx.helper(RuntimeHelper::ResolveDirective);
+                    let imported_binding = imported_directive_binding_name(&dir.name);
+                    if !ctx.is_variable_defined(imported_binding.as_str()) {
+                        ctx.helper(RuntimeHelper::ResolveDirective);
+                    }
                     ctx.add_directive(dir.name.clone());
                 }
                 _ => {}

--- a/crates/vize_atelier_core/src/transforms.rs
+++ b/crates/vize_atelier_core/src/transforms.rs
@@ -25,8 +25,9 @@ pub use transform_element::{
     TransformPropsExpression, TransformVNodeCall,
 };
 pub use transform_expression::{
-    is_simple_identifier, prefix_identifiers_in_expression, process_expression,
-    process_inline_handler, strip_typescript_from_expression,
+    is_event_handler_reference_expression, is_simple_identifier,
+    prefix_identifiers_in_expression, process_expression, process_inline_handler,
+    strip_typescript_from_expression,
 };
 pub use transform_text::{
     build_text_call, condense_whitespace, is_condensible_whitespace, is_whitespace_only,

--- a/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
@@ -319,6 +319,9 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
         for param in &arrow.params.items {
             self.collect_binding_pattern(&param.pattern);
         }
+        if let Some(rest) = &arrow.params.rest {
+            self.collect_binding_pattern(&rest.rest.argument);
+        }
 
         // Visit body
         self.visit_function_body(&arrow.body);

--- a/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use super::{
     clone_expression,
+    is_event_handler_reference_expression,
     prefix::{get_identifier_prefix, is_simple_identifier},
     rewrite::rewrite_expression,
     typescript::strip_typescript_from_expression,
@@ -80,19 +81,28 @@ pub fn process_inline_handler<'a>(
                 return clone_expression(exp, allocator);
             }
 
-            // Check if it's a simple identifier (method name)
-            // Vue passes method references directly, no wrapping needed
-            if is_simple_identifier(content) {
+            // Check if it's an identifier/member-expression handler reference.
+            // Vue passes these directly without wrapping them in `$event => (...)`.
+            if is_simple_identifier(content) || is_event_handler_reference_expression(content) {
                 let new_content: String = if ctx.options.prefix_identifiers {
-                    // Use the same prefix logic as get_identifier_prefix for consistency
-                    if let Some(prefix) = get_identifier_prefix(content, ctx) {
-                        let mut s = String::with_capacity(prefix.len() + content.len());
-                        s.push_str(prefix);
-                        s.push_str(content);
-                        s
+                    if is_simple_identifier(content) {
+                        if let Some(prefix) = get_identifier_prefix(content, ctx) {
+                            let mut s = String::with_capacity(prefix.len() + content.len());
+                            s.push_str(prefix);
+                            s.push_str(content);
+                            s
+                        } else {
+                            content.clone()
+                        }
                     } else {
-                        content.clone()
+                        let result = rewrite_expression(content, ctx, false);
+                        if result.used_unref {
+                            ctx.helper(crate::ast::RuntimeHelper::Unref);
+                        }
+                        result.code
                     }
+                } else if ctx.options.is_ts {
+                    strip_typescript_from_expression(content)
                 } else {
                     content.clone()
                 };

--- a/crates/vize_atelier_core/src/transforms/transform_expression/mod.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/mod.rs
@@ -9,6 +9,9 @@ pub(crate) mod prefix;
 mod rewrite;
 mod typescript;
 
+use oxc_ast::ast::{ChainElement, Expression};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use vize_carton::{Box, Bump, String};
 
 use crate::{
@@ -21,6 +24,29 @@ pub use prefix::{is_simple_identifier, prefix_identifiers_in_expression};
 pub use typescript::strip_typescript_from_expression;
 
 use rewrite::rewrite_expression;
+
+/// Returns true if an expression is a callable reference that should be passed
+/// through directly as an event handler, not wrapped as `$event => (...)`.
+pub fn is_event_handler_reference_expression(content: &str) -> bool {
+    let allocator = oxc_allocator::Allocator::default();
+    let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
+    let Ok(expr) = parser.parse_expression() else {
+        return false;
+    };
+
+    match expr {
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => true,
+        Expression::ChainExpression(chain) => matches!(
+            chain.expression,
+            ChainElement::StaticMemberExpression(_)
+                | ChainElement::ComputedMemberExpression(_)
+        ),
+        _ => false,
+    }
+}
 
 /// Process expression with identifier prefixing and TypeScript stripping
 pub fn process_expression<'a>(

--- a/crates/vize_atelier_dom/tests/dom_snapshot.rs
+++ b/crates/vize_atelier_dom/tests/dom_snapshot.rs
@@ -201,4 +201,59 @@ mod component {
     fn simple_component() {
         insta::assert_snapshot!(get_compiled("<MyComponent></MyComponent>"));
     }
+
+    #[test]
+    fn dynamic_component_uses_block_in_non_block_context() {
+        let code = get_compiled(r#"<div><component :is="current" /></div>"#);
+        assert!(
+            code.contains("(_openBlock(), _createBlock(_resolveDynamicComponent("),
+            "dynamic component should use block form in nested context:\n{code}"
+        );
+    }
+
+    #[test]
+    fn forwarded_slot_flag_is_emitted() {
+        let code = get_compiled(r#"<component :is="current"><slot /></component>"#);
+        assert!(
+            code.contains("_: 3 /* FORWARDED */"),
+            "forwarded slot should use FORWARDED slot flag:\n{code}"
+        );
+    }
+
+    #[test]
+    fn dynamic_slot_still_uses_dynamic_flag_even_with_slot_forwarding() {
+        let code = get_compiled(r#"<Comp><template #[name]><slot /></template></Comp>"#);
+        assert!(
+            code.contains("_: 2 /* DYNAMIC */"),
+            "dynamic slots should keep DYNAMIC slot flag:\n{code}"
+        );
+    }
+
+    #[test]
+    fn sibling_v_if_groups_get_unique_auto_keys() {
+        let code = get_compiled(r#"<div><span v-if="a">A</span><span v-if="b">B</span></div>"#);
+        assert!(
+            code.contains("{ key: 0 }"),
+            "first v-if group should use key 0:\n{code}"
+        );
+        assert!(
+            code.contains("{ key: 1 }"),
+            "second v-if group should use key 1:\n{code}"
+        );
+    }
+
+    #[test]
+    fn slot_outlet_in_v_if_branch_uses_render_slot() {
+        let code = get_compiled(
+            r#"<button><slot v-if="ok" name="icon" /><slot v-else /></button>"#,
+        );
+        assert!(
+            code.contains("_renderSlot(_ctx.$slots, \"icon\", { key: 0"),
+            "slot v-if branch should compile to renderSlot:\n{code}"
+        );
+        assert!(
+            code.contains("_renderSlot(_ctx.$slots, \"default\", { key: 1"),
+            "slot v-else branch should compile to renderSlot:\n{code}"
+        );
+    }
 }

--- a/crates/vize_atelier_sfc/src/compile/mod.rs
+++ b/crates/vize_atelier_sfc/src/compile/mod.rs
@@ -283,7 +283,7 @@ pub fn compile_sfc(
     };
 
     // 1. Croquis parser: rich analysis with ReactivityTracker
-    let croquis = crate::script::analyze_script_setup_to_summary(&script_setup.content);
+    let mut croquis = crate::script::analyze_script_setup_to_summary(&script_setup.content);
     let mut script_bindings = croquis_to_legacy_bindings(&croquis.bindings);
 
     // 2. ScriptCompileContext: needed for macro span info and TypeScript type resolution
@@ -303,12 +303,31 @@ pub fn compile_sfc(
     }
     ctx.analyze();
 
-    // 3. Merge Props bindings from ScriptCompileContext (type resolution fallback)
-    //    Croquis can't resolve interface references, so we take Props from the legacy analyzer
+    // 3. Merge bindings from ScriptCompileContext that need type-aware fallback.
+    //    Croquis handles most setup analysis, but ScriptCompileContext can infer
+    //    additional ref-like bindings from TypeScript generics (e.g. inject<Ref<T>>)
+    //    and resolve Props from interface/type references.
     for (name, bt) in &ctx.bindings.bindings {
-        if matches!(bt, BindingType::Props | BindingType::PropsAliased) {
-            script_bindings.bindings.entry(name.clone()).or_insert(*bt);
+        if matches!(
+            bt,
+            BindingType::Props
+                | BindingType::PropsAliased
+                | BindingType::SetupRef
+                | BindingType::SetupMaybeRef
+                | BindingType::SetupReactiveConst
+        ) {
+            script_bindings.bindings.insert(name.clone(), *bt);
+            croquis.bindings.add(name.as_str(), *bt);
         }
+    }
+    for (local, key) in &ctx.bindings.props_aliases {
+        script_bindings
+            .props_aliases
+            .insert(local.clone(), key.clone());
+        croquis
+            .bindings
+            .props_aliases
+            .insert(local.clone(), key.clone());
     }
 
     // Register $emit or __emit binding when defineEmits is used, so the template
@@ -320,9 +339,19 @@ pub fn compile_sfc(
                 .bindings
                 .entry(binding_name.clone())
                 .or_insert(BindingType::SetupConst);
+            croquis
+                .bindings
+                .bindings
+                .entry(binding_name.clone())
+                .or_insert(BindingType::SetupConst);
         } else {
             // defineEmits([...]) without assignment -> $emit is exposed in setup args
             script_bindings
+                .bindings
+                .entry("$emit".to_compact_string())
+                .or_insert(BindingType::SetupConst);
+            croquis
+                .bindings
                 .bindings
                 .entry("$emit".to_compact_string())
                 .or_insert(BindingType::SetupConst);

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -336,6 +336,11 @@ const activeTab = ref<'a' | 'b'>('a');
 </template>"#;
 
     let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let script_setup = descriptor.script_setup.as_ref().expect("script setup");
+    let mut ctx = crate::script::ScriptCompileContext::new(&script_setup.content);
+    ctx.analyze();
+    eprintln!("dynamic ctx reference binding: {:?}", ctx.bindings.bindings.get("reference"));
+    eprintln!("dynamic ctx floating binding: {:?}", ctx.bindings.bindings.get("floating"));
     let result =
         compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
 
@@ -347,6 +352,30 @@ const activeTab = ref<'a' | 'b'>('a');
     assert!(
         result.code.contains("activeTab.value === 'a'"),
         "Expected ref access to stay reactive in class binding. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_inline_template_injected_ref_assignment_uses_value() {
+    let source = r#"<script setup lang="ts">
+import { inject, type Ref } from 'vue';
+
+const status = inject<Ref<'closing' | 'opening'>>('status');
+</script>
+
+<template>
+  <button @click="status = 'closing'">{{ status }}</button>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("status.value = \"closing\"")
+            || result.code.contains("status.value = 'closing'"),
+        "Expected injected ref assignment to target `.value`. Got:\n{}",
         result.code
     );
 }
@@ -430,6 +459,75 @@ const currentCode = ref('dom');
     assert!(
         result.code.contains("[\"code\"]"),
         "Expected v-if branch component dynamic props list to include code. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_options_api_dynamic_style_and_class_keep_patch_flags() {
+    let source = r#"<script>
+export default {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+</script>
+
+<template>
+  <div class="map">
+    <div :style="knobStyle" :class="{ dragging }"></div>
+  </div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("6 /* CLASS, STYLE */")
+            || result.code.contains("4 /* STYLE */")
+            || result.code.contains("2 /* CLASS */"),
+        "Expected options API dynamic style/class to preserve patch flags. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_inline_v_if_branch_maybe_ref_style_keeps_style_patch_flag() {
+    let source = r#"<script setup lang="ts">
+import { ref } from 'vue'
+
+const show = ref(true)
+const floatingStyles = ref({ left: '10px', top: '20px' })
+</script>
+
+<template>
+  <div v-if="show" :style="floatingStyles"></div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let script_setup = descriptor.script_setup.as_ref().expect("script setup");
+    let mut ctx = crate::script::ScriptCompileContext::new(&script_setup.content);
+    ctx.analyze();
+    assert_eq!(
+        ctx.bindings.bindings.get("floatingStyles"),
+        Some(&BindingType::SetupRef),
+        "Expected destructured useFloating style binding to be treated as ref-like. Got: {:?}",
+        ctx.bindings.bindings.get("floatingStyles")
+    );
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("floatingStyles.value") || result.code.contains("_unref(floatingStyles)"),
+        "Expected maybe-ref style binding to stay reactive. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("4 /* STYLE */") || result.code.contains("6 /* CLASS, STYLE */"),
+        "Expected v-if branch style binding to preserve STYLE patch flag. Got:\n{}",
         result.code
     );
 }
@@ -539,6 +637,345 @@ var c = 3
 }
 
 #[test]
+fn test_component_event_member_expression_handler_is_not_wrapped() {
+    let source = r#"<script setup>
+const actionHandler = useActionHandler()
+</script>
+
+<template>
+  <ActionPanel @selectItem="actionHandler.selectItem" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        !result
+            .code
+            .contains("onSelectItem: ($event) => _unref(actionHandler).selectItem"),
+        "member-expression component listener should not be wrapped in a no-op arrow. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result
+            .code
+            .contains("_unref(actionHandler).selectItem(...args)"),
+        "member-expression component listener should invoke the method reference. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_component_event_rest_param_handler_keeps_rest_args_local() {
+    let source = r#"<script setup>
+const emit = defineEmits(['update'])
+</script>
+
+<template>
+  <Child @update="(...$args) => emit('update', ...$args)" @change="(...args) => emit('update', ...args)" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("(...$args) =>")
+            && result.code.contains("...$args"),
+        "rest-param component listener should keep $args local. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("(...args) =>")
+            && result.code.contains("...args"),
+        "rest-param component listener should keep args local. Got:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("..._ctx.$args") && !result.code.contains("..._ctx.args"),
+        "rest-param component listener should not rewrite rest args through _ctx. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_destructured_composable_binding_is_not_rewritten_to_props_in_slot_scope() {
+    let source = r#"<script setup>
+const { format } = useFormatter(catalog)
+</script>
+
+<template>
+  <PopupMenu>
+    <template #trigger>
+      <span>{{ format('hello') }}</span>
+    </template>
+  </PopupMenu>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("__props.format("),
+        "destructured composable binding should not be rewritten to props in slot scope. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("format('hello')") || result.code.contains("_unref(format)('hello')"),
+        "destructured composable binding should remain a setup binding in slot scope. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_destructured_composable_binding_survives_destructured_slot_scope() {
+    let source = r#"<script setup>
+const { format } = useFormatter(catalog)
+</script>
+
+<template>
+  <PopupMenu>
+    <template #items="{ close }">
+      <button @click="close()">{{ format('hello') }}</button>
+    </template>
+  </PopupMenu>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("__props.format("),
+        "destructured composable binding should not be rewritten to props when slot params are destructured. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_destructured_composable_binding_survives_nested_slot_scopes() {
+    let source = r#"<script setup>
+const { format } = useFormatter(catalog)
+const items = ['a']
+</script>
+
+<template>
+  <PopupMenu>
+    <template #items="{ close }">
+      <template v-for="item in items" :key="item">
+        <OptionRow v-slot="{ active }">
+          <li :class="{ active }" @click="close()">{{ format(item) }}</li>
+        </OptionRow>
+      </template>
+    </template>
+  </PopupMenu>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("__props.format("),
+        "destructured composable binding should not be rewritten to props in nested slot scopes. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_function_typed_prop_param_does_not_override_local_t_in_slot_scope() {
+    let source = r#"<script setup lang="ts">
+const { format } = useFormatter(catalog)
+const props = defineProps<{
+  renderLabel: (value: string, format: any) => string
+}>()
+</script>
+
+<template>
+  <PopupMenu>
+    <template #items="{ close }">
+      <OptionRow v-slot="{ active }">
+        <li :class="{ active }" @click="close()">
+          <span>{{ format('hello') }}</span>
+          <span>{{ renderLabel('x', format) }}</span>
+        </li>
+      </OptionRow>
+    </template>
+  </PopupMenu>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("__props.format("),
+        "local composable binding should not be rewritten to props inside slot scopes even when a prop function type uses the same parameter name. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("renderLabel('x', format)")
+            || result.code.contains("renderLabel(\"x\", format)")
+            || result.code.contains("renderLabel('x', _unref(format))")
+            || result.code.contains("renderLabel(\"x\", _unref(format))"),
+        "local binding should remain the second argument passed to the prop callback. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_fast_and_full_analysis_agree_on_local_t_when_prop_fn_type_uses_t_param() {
+    let source = r#"
+import type { Composer } from 'vue-i18n'
+
+const { format } = useFormatter(catalog)
+const props = defineProps<{
+  renderLabel: (value: string, format: Composer['t']) => string
+}>()
+"#;
+
+    let fast = crate::script::analyze_script_setup_to_summary(source);
+    let full = crate::script::analyze_script_setup_full(source);
+
+    assert_eq!(
+        fast.bindings.get("format"),
+        Some(BindingType::SetupMaybeRef),
+        "fast analysis should keep the local destructured binding as a setup binding. Got: {:?}",
+        fast.bindings.get("format")
+    );
+    assert_eq!(
+        full.bindings.get("format"),
+        Some(BindingType::SetupMaybeRef),
+        "full analysis should keep the local destructured binding as a setup binding. Got: {:?}",
+        full.bindings.get("format")
+    );
+}
+
+#[test]
+fn test_template_compile_keeps_local_t_in_slot_scope_with_prop_fn_param_name_collision() {
+    let source = r#"<script setup lang="ts">
+import type { Composer } from 'vue-i18n'
+
+const { format } = useFormatter(catalog)
+const props = defineProps<{
+  groupedItems: string[]
+  activeItem: string | null
+  highlightedItems: string[]
+  getItemKind: (value: string) => string | null
+  renderLabel: (value: string, format: Composer['t']) => string
+  selectedNodes: unknown[]
+  hasNestedSelection: boolean
+  itemGroups: { group: string; values: string[] }[]
+}>()
+</script>
+
+<template>
+  <PopupMenu>
+    <template #trigger>
+      <div>
+        <span>{{ format('Item: default') }}</span>
+      </div>
+    </template>
+    <template #items="{ close }">
+      <ul>
+        <li v-for="{ group, values } of itemGroups" :key="group" class="item-group">
+          <p class="item-group-title">
+            <span>{{ format(`ItemGroup: ${group}`) }}</span>
+          </p>
+          <ul class="selection">
+            <template v-for="value of values" :key="value">
+              <OptionRow v-slot="{ active }">
+                <li
+                  class="selection-item"
+                  :class="{ selected: value === activeItem, highlighted: highlightedItems.includes(value), active: active }"
+                  :data-kind="getItemKind(value)"
+                  @click="close()"
+                >
+                  <span class="value">{{ renderLabel(value, format) }}</span>
+                </li>
+              </OptionRow>
+            </template>
+          </ul>
+        </li>
+      </ul>
+    </template>
+  </PopupMenu>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let script_setup = descriptor.script_setup.as_ref().expect("script setup");
+    let template = descriptor.template.as_ref().expect("template");
+
+    let mut croquis = crate::script::analyze_script_setup_to_summary(&script_setup.content);
+    let mut script_bindings = super::bindings::croquis_to_legacy_bindings(&croquis.bindings);
+    let mut ctx = crate::script::ScriptCompileContext::new(&script_setup.content);
+    ctx.analyze();
+
+    for (name, bt) in &ctx.bindings.bindings {
+        if matches!(
+            bt,
+            BindingType::Props
+                | BindingType::PropsAliased
+                | BindingType::SetupRef
+                | BindingType::SetupMaybeRef
+                | BindingType::SetupReactiveConst
+        ) {
+            script_bindings.bindings.insert(name.clone(), *bt);
+            croquis.bindings.add(name.as_str(), *bt);
+        }
+    }
+    for (local, key) in &ctx.bindings.props_aliases {
+        script_bindings
+            .props_aliases
+            .insert(local.clone(), key.clone());
+        croquis
+            .bindings
+            .props_aliases
+            .insert(local.clone(), key.clone());
+    }
+
+    assert_eq!(
+        script_bindings.bindings.get("format"),
+        Some(&BindingType::SetupMaybeRef),
+        "legacy binding metadata should keep the local binding as a setup binding. Got: {:?}",
+        script_bindings.bindings.get("format")
+    );
+    assert_eq!(
+        croquis.bindings.get("format"),
+        Some(BindingType::SetupMaybeRef),
+        "croquis bindings should keep the local binding as a setup binding. Got: {:?}",
+        croquis.bindings.get("format")
+    );
+
+    let output = crate::compile_template::compile_template_block(
+        template,
+        &TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        "test-scope",
+        false,
+        true,
+        Some(&script_bindings),
+        Some(croquis),
+    )
+    .expect("template compile should succeed");
+
+    assert!(
+        !output.contains("__props.format("),
+        "template compiler should not rewrite the local binding to props inside slot scope. Got:\n{}",
+        output
+    );
+}
+
+#[test]
 fn test_extract_normal_script_content() {
     let input = r#"import type { NuxtRoute } from "@typed-router";
 import { useBreakpoint } from "./_utils";
@@ -581,6 +1018,83 @@ export default {
     assert!(
         !result.contains("export default"),
         "Should NOT contain export default"
+    );
+}
+
+#[test]
+fn test_template_ref_uses_setup_ref_binding_in_inline_mode() {
+    let source = r#"<script setup lang="ts">
+import { ref } from 'vue'
+const reference = ref<HTMLElement>()
+const floating = ref<HTMLElement>()
+</script>
+
+<template>
+  <button ref="reference">open</button>
+  <div ref="floating">panel</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("ref_key: \"reference\", ref: reference"),
+        "template ref should bind to setup ref `reference`. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("ref_key: \"floating\", ref: floating"),
+        "template ref should bind to setup ref `floating`. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_template_ref_uses_setup_ref_binding_with_dynamic_props() {
+    let source = r#"<script setup lang="ts">
+import { computed, ref } from 'vue'
+const reference = ref<HTMLElement>()
+const floating = ref<HTMLElement>()
+const isOpen = ref(true)
+const klass = computed(() => 'x')
+const styles = computed(() => ({ left: '0px', top: '0px' }))
+function toggle() {}
+</script>
+
+<template>
+  <button
+    v-if="isOpen"
+    ref="reference"
+    :id="isOpen ? 'open' : undefined"
+    class="base"
+    :class="klass"
+    @click="toggle"
+  >
+    open
+  </button>
+  <div
+    v-if="isOpen"
+    ref="floating"
+    :style="styles"
+  >
+    panel
+  </div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("ref_key: \"reference\", ref: reference"),
+        "dynamic props should preserve setup ref `reference`. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("ref_key: \"floating\", ref: floating"),
+        "dynamic props should preserve setup ref `floating`. Got:\n{}",
+        result.code
     );
 }
 
@@ -1290,6 +1804,49 @@ import FooPanel from './FooPanel.vue'
     assert!(
         !result.code.contains("_resolveComponent(\"FooPanel\")"),
         "Imported script setup components should not go through resolveComponent. Got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_script_setup_keeps_imported_custom_directive_binding() {
+    let source = r#"<script setup lang="ts">
+import { vElementHover } from '@vueuse/components'
+</script>
+
+<template>
+  <div v-element-hover="() => {}" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains("import { vElementHover } from '@vueuse/components'"),
+        "Imported custom directive binding should be preserved. Got:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("_resolveDirective(\"element-hover\")"),
+        "Imported custom directives should not be resolved from app context. Got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("vElementHover"),
+        "Generated directive usage should reference the imported binding. Got:\n{}",
         result.code
     );
 }

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -16,7 +16,9 @@ use super::super::import_utils::extract_import_identifiers;
 use super::super::macros::{
     is_macro_call_line, is_multiline_macro_start, is_paren_macro_start, is_props_destructure_line,
 };
-use super::super::props::{extract_emit_names_from_type, extract_prop_types_from_type};
+use super::super::props::{
+    add_null_to_runtime_type, extract_emit_names_from_type, extract_prop_types_from_type,
+};
 use super::super::typescript::transform_typescript_to_js;
 use super::super::ScriptCompileResult;
 use super::helpers::{
@@ -680,13 +682,15 @@ fn emit_props_definition(
                 let mut sorted_props: Vec<_> = prop_types.iter().collect();
                 sorted_props.sort_by(|a, b| a.0.cmp(&b.0));
                 for (name, prop_type) in sorted_props {
+                    let runtime_js_type =
+                        add_null_to_runtime_type(&prop_type.js_type, prop_type.nullable);
                     output.extend_from_slice(b"    ");
                     output.extend_from_slice(name.as_bytes());
                     output.extend_from_slice(b": { type: ");
-                    output.extend_from_slice(prop_type.js_type.as_bytes());
+                    output.extend_from_slice(runtime_js_type.as_bytes());
                     if needs_prop_type {
                         if let Some(ref ts_type) = prop_type.ts_type {
-                            if prop_type.js_type == "null" {
+                            if runtime_js_type == "null" {
                                 output.extend_from_slice(b" as unknown as PropType<");
                             } else {
                                 output.extend_from_slice(b" as PropType<");

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -19,11 +19,14 @@ use super::super::macros::{
     is_macro_call_line, is_multiline_macro_start, is_paren_macro_start, is_props_destructure_line,
 };
 use super::super::props::{
-    extract_emit_names_from_type, extract_prop_types_from_type, extract_with_defaults_defaults,
+    add_null_to_runtime_type, extract_emit_names_from_type, extract_prop_types_from_type,
+    extract_with_defaults_defaults,
 };
 use super::super::typescript::transform_typescript_to_js;
 use super::super::{ScriptCompileResult, TemplateParts};
-use super::helpers::{extract_const_name, strip_comments_for_counting};
+use super::helpers::{
+    extract_const_name, strip_comments_and_strings_for_counting, strip_comments_for_counting,
+};
 use super::type_handling::resolve_type_args;
 
 const VAPOR_RENDER_ALIAS_BASE: &str = "__vaporRender";
@@ -914,8 +917,9 @@ fn parse_script_content(content: &str, is_ts: bool) -> (Vec<String>, Vec<String>
         if in_object_literal {
             object_literal_buffer.push_str(line);
             object_literal_buffer.push('\n');
-            object_literal_brace_depth += trimmed.matches('{').count() as i32;
-            object_literal_brace_depth -= trimmed.matches('}').count() as i32;
+            let cleaned = strip_comments_and_strings_for_counting(trimmed);
+            object_literal_brace_depth += cleaned.matches('{').count() as i32;
+            object_literal_brace_depth -= cleaned.matches('}').count() as i32;
             if object_literal_brace_depth <= 0 {
                 // Object literal is complete, add to setup_lines
                 for buf_line in object_literal_buffer.lines() {
@@ -931,16 +935,16 @@ fn parse_script_content(content: &str, is_ts: bool) -> (Vec<String>, Vec<String>
         if (trimmed.starts_with("const ")
             || trimmed.starts_with("let ")
             || trimmed.starts_with("var "))
-            && trimmed.contains('=')
-            && trimmed.ends_with('{')
             && !trimmed.contains("defineProps")
             && !trimmed.contains("defineEmits")
             && !trimmed.contains("defineModel")
+            && is_strict_multiline_object_literal_start(trimmed)
         {
             in_object_literal = true;
             object_literal_buffer = line.to_compact_string() + "\n";
+            let cleaned = strip_comments_and_strings_for_counting(trimmed);
             object_literal_brace_depth =
-                trimmed.matches('{').count() as i32 - trimmed.matches('}').count() as i32;
+                cleaned.matches('{').count() as i32 - cleaned.matches('}').count() as i32;
             continue;
         }
 
@@ -1210,6 +1214,29 @@ fn parse_script_content(content: &str, is_ts: bool) -> (Vec<String>, Vec<String>
     (user_imports, setup_lines, ts_declarations)
 }
 
+/// True only for strict multiline object literal starts like:
+/// - `const x = {`
+/// - `const x: T = {`
+///
+/// Excludes function blocks such as:
+/// - `const x = computed(() => {`
+/// - `const x = fn({`
+fn is_strict_multiline_object_literal_start(line: &str) -> bool {
+    let without_comments = strip_comments_for_counting(line);
+    let trimmed = without_comments.trim();
+
+    if !trimmed.ends_with('{') {
+        return false;
+    }
+
+    let before_brace = trimmed[..trimmed.len() - 1].trim_end();
+    let Some(eq_idx) = before_brace.rfind('=') else {
+        return false;
+    };
+
+    before_brace[eq_idx + 1..].trim().is_empty()
+}
+
 /// Build props and emits definition buffer from context macros.
 fn build_props_emits(
     ctx: &ScriptCompileContext,
@@ -1256,10 +1283,12 @@ fn build_props_emits(
                     } else {
                         prop_type.js_type.clone()
                     };
+                    let runtime_js_type =
+                        add_null_to_runtime_type(&resolved_js_type, prop_type.nullable);
                     props_emits_buf.extend_from_slice(b"    ");
                     props_emits_buf.extend_from_slice(name.as_bytes());
                     props_emits_buf.extend_from_slice(b": { type: ");
-                    props_emits_buf.extend_from_slice(resolved_js_type.as_bytes());
+                    props_emits_buf.extend_from_slice(runtime_js_type.as_bytes());
                     if needs_prop_type {
                         if let Some(ref ts_type) = prop_type.ts_type {
                             if resolved_js_type == "null" {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/helpers.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/helpers.rs
@@ -53,6 +53,64 @@ pub(crate) fn strip_comments_for_counting(line: &str) -> String {
     result
 }
 
+/// Strip comments and string literals from a line for brace/paren counting.
+/// Removes:
+/// - `// ...` line comments
+/// - `/* ... */` block comments (single-line)
+/// - `'...'`, `"..."`, and `` `...` `` string/template literal contents
+///
+/// Keeps non-string code intact so structural tokens (`{}`, `()`, `<>`) can be counted safely.
+pub(crate) fn strip_comments_and_strings_for_counting(line: &str) -> String {
+    let mut result = String::with_capacity(line.len());
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut string_char = b'"';
+
+    while i < bytes.len() {
+        if in_string {
+            if bytes[i] == b'\\' {
+                i += 1;
+                if i < bytes.len() {
+                    i += 1;
+                }
+                continue;
+            }
+            if bytes[i] == string_char {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        match bytes[i] {
+            b'\'' | b'"' | b'`' => {
+                in_string = true;
+                string_char = bytes[i];
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                break;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            _ => {
+                result.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+    }
+
+    result
+}
+
 /// Extract the variable name from a const declaration line.
 /// e.g., "const msg = 'hello'" -> Some("msg")
 /// e.g., "const count = ref(0)" -> Some("count")

--- a/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
@@ -126,6 +126,40 @@ const identifier =
     }
 
     #[test]
+    fn test_arrow_function_block_not_misdetected_as_object_literal() {
+        let content = r#"
+import { computed } from 'vue'
+
+const inputValue = 'prefix {{foo}} suffix'
+const isVariable = computed(() => {
+  return inputValue.includes('{{')
+})
+const reference = computed(() => {
+  return isVariable.value ? inputValue.match(/{{([^{}]+)}}/) : null
+})
+"#;
+        let output = compile_setup(content);
+        let is_variable_pos = output.find("const isVariable = computed(() => {");
+        let reference_pos = output.find("const reference = computed(() => {");
+
+        assert!(
+            is_variable_pos.is_some(),
+            "isVariable declaration should be preserved. Got:\n{}",
+            output
+        );
+        assert!(
+            reference_pos.is_some(),
+            "reference declaration should be preserved. Got:\n{}",
+            output
+        );
+        assert!(
+            reference_pos.unwrap() > is_variable_pos.unwrap(),
+            "reference should appear after isVariable. Got:\n{}",
+            output
+        );
+    }
+
+    #[test]
     fn test_destructure_with_multiline_function_call() {
         let content = r#"
 import { ref, toRef } from 'vue'

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -19,6 +19,8 @@ pub struct PropTypeInfo {
     pub ts_type: Option<String>,
     /// Whether the prop is optional
     pub optional: bool,
+    /// Whether the prop accepts null at runtime
+    pub nullable: bool,
 }
 
 /// Strip TypeScript comments from source while preserving string literals.
@@ -179,7 +181,8 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
         let name_part = &trimmed[..colon_pos];
         let type_part = &trimmed[colon_pos + 1..];
 
-        let optional = name_part.ends_with('?');
+        let optional = name_part.ends_with('?') || type_includes_top_level_undefined(type_part);
+        let nullable = type_includes_top_level_null(type_part);
         let name = name_part.trim().trim_end_matches('?').trim();
 
         if !name.is_empty() && is_valid_identifier(name) {
@@ -193,11 +196,57 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
                         js_type,
                         ts_type: Some(ts_type_str),
                         optional,
+                        nullable,
                     },
                 ));
             }
         }
     }
+}
+
+fn type_includes_top_level_undefined(ts_type: &str) -> bool {
+    split_type_at_top_level(ts_type.trim(), '|')
+        .into_iter()
+        .any(|part| part.trim() == "undefined")
+}
+
+fn type_includes_top_level_null(ts_type: &str) -> bool {
+    split_type_at_top_level(ts_type.trim(), '|')
+        .into_iter()
+        .any(|part| part.trim() == "null")
+}
+
+pub fn add_null_to_runtime_type(js_type: &str, nullable: bool) -> String {
+    if !nullable || js_type == "null" {
+        return js_type.to_compact_string();
+    }
+
+    if js_type.starts_with('[') && js_type.ends_with(']') {
+        let inner = &js_type[1..js_type.len() - 1];
+        if inner
+            .split(',')
+            .map(|part| part.trim())
+            .any(|part| part == "null")
+        {
+            return js_type.to_compact_string();
+        }
+
+        let mut result = String::with_capacity(js_type.len() + 6);
+        result.push('[');
+        result.push_str(inner);
+        if !inner.trim().is_empty() {
+            result.push_str(", ");
+        }
+        result.push_str("null");
+        result.push(']');
+        return result;
+    }
+
+    let mut result = String::with_capacity(js_type.len() + 8);
+    result.push('[');
+    result.push_str(js_type);
+    result.push_str(", null]");
+    result
 }
 
 /// Split a type string at a delimiter only at the top level (depth 0),
@@ -380,6 +429,10 @@ fn ts_type_to_js_type(ts_type: &str) -> String {
                     | "URL" | "URLSearchParams" | "FormData" | "Blob" | "File" => {
                         type_name.to_compact_string()
                     }
+                    // Built-in TypeScript utility types that erase to plain objects at runtime
+                    "Record" | "Partial" | "Required" | "Readonly" | "Pick" | "Omit" => {
+                        "Object".to_compact_string()
+                    }
                     // Vue reactive types that are objects at runtime
                     "Ref"
                     | "ShallowRef"
@@ -387,7 +440,6 @@ fn ts_type_to_js_type(ts_type: &str) -> String {
                     | "WritableComputedRef"
                     | "MaybeRef"
                     | "MaybeRefOrGetter"
-                    | "Readonly"
                     | "UnwrapRef"
                     | "Reactive"
                     | "ShallowReactive"
@@ -494,11 +546,34 @@ pub fn strip_readonly_prefix(ts_type: &str) -> &str {
 /// Extract emit names from TypeScript type definition
 pub fn extract_emit_names_from_type(type_args: &str) -> Vec<String> {
     let mut emits = Vec::new();
+    let trimmed = type_args.trim();
+
+    // Handle call signature formats first:
+    //   (e: 'click') => void
+    //   { (e: 'click'): void; (e: 'update', value: string): void }
+    //   { (_: 'toggleAssetPicker', isOpen: boolean): void }
+    let call_sig_re =
+        regex::Regex::new(r#"(?x)
+            \(\s*
+                [A-Za-z_$][A-Za-z0-9_$]*\s*:\s*
+                ['"]([^'"]+)['"]
+            "#)
+        .unwrap();
+    for cap in call_sig_re.captures_iter(trimmed) {
+        if let Some(event_name) = cap.get(1) {
+            let event_name = event_name.as_str();
+            if !event_name.is_empty() && !emits.iter().any(|name| name == event_name) {
+                emits.push(event_name.to_compact_string());
+            }
+        }
+    }
+    if !emits.is_empty() {
+        return emits;
+    }
 
     // First, try Vue 3.3+ shorthand format:
     //   { change: [value: string]; submit: []; update: [id: number] }
     // Property names before `:` followed by `[` are event names
-    let trimmed = type_args.trim();
     let is_shorthand = trimmed.starts_with('{')
         && trimmed.contains('[')
         && !trimmed.contains("(e:")

--- a/crates/vize_atelier_sfc/src/compile_script/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/tests.rs
@@ -619,6 +619,83 @@ const itemCount = computed(() => items.length)
         assert!(find("count").unwrap().optional);
         assert!(find("disabled").unwrap().optional);
         assert!(find("items").unwrap().optional);
+
+    }
+
+    #[test]
+    fn test_extract_prop_types_with_union_runtime_types() {
+        let type_args = r#"{
+  focusedRenderId: string | undefined
+  activeKey: string | null
+  items: Array<{ id: string; key: string; label: string }> | null
+  tabListClass?: string | Record<string, boolean> | (string | Record<string, boolean>)[]
+  refreshMethod: (loaded: Function) => Promise<void> | void
+  boolish: boolean | number | undefined
+}"#;
+        let props = extract_prop_types_from_type(type_args);
+        let find = |name: &str| props.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+
+        assert_eq!(find("focusedRenderId").unwrap().js_type, "String");
+        assert!(find("focusedRenderId").unwrap().optional);
+        assert!(!find("focusedRenderId").unwrap().nullable);
+        assert_eq!(find("activeKey").unwrap().js_type, "String");
+        assert!(find("activeKey").unwrap().nullable);
+        assert_eq!(find("items").unwrap().js_type, "Array");
+        assert!(find("items").unwrap().nullable);
+        assert_eq!(
+            find("tabListClass").unwrap().js_type,
+            "[String, Object, Array]"
+        );
+        assert!(!find("tabListClass").unwrap().nullable);
+        assert_eq!(find("refreshMethod").unwrap().js_type, "Function");
+        assert_eq!(find("boolish").unwrap().js_type, "[Boolean, Number]");
+        assert!(find("boolish").unwrap().optional);
+        assert!(!find("boolish").unwrap().nullable);
+    }
+
+    #[test]
+    fn test_compile_script_setup_runtime_props_for_nullable_record_and_undefined_union() {
+        let content = r#"
+const props = defineProps<{
+  focusedRenderId: string | undefined
+  groupLabel: string | undefined
+  activeKey: string | null
+  items: Array<{ id: string; key: string; label: string }> | null
+  tabListClass?: string | Record<string, boolean> | (string | Record<string, boolean>)[]
+}>()
+"#;
+        let result = compile_script_setup(content, "Test", false, true, None).unwrap();
+
+        let code = &result.code;
+        assert!(
+            code.contains("focusedRenderId: { type: String as PropType<string | undefined>, required: false }"),
+            "focusedRenderId should be optional when undefined is part of the union. Got:\n{}",
+            code
+        );
+        assert!(
+            code.contains("groupLabel: { type: String as PropType<string | undefined>, required: false }"),
+            "groupLabel should be optional when undefined is part of the union. Got:\n{}",
+            code
+        );
+        assert!(
+            code.contains("activeKey: { type: [String, null] as PropType<string | null>, required: true }"),
+            "activeKey should accept null at runtime. Got:\n{}",
+            code
+        );
+        assert!(
+            code.contains(
+                "items: { type: [Array, null] as PropType<Array<{ id: string; key: string; label: string }> | null>, required: true }"
+            ),
+            "items should accept null at runtime. Got:\n{}",
+            code
+        );
+        assert!(
+            code.contains(
+                "tabListClass: { type: [String, Object, Array] as PropType<string | Record<string, boolean> | (string | Record<string, boolean>)[]>, required: false }"
+            ),
+            "tabListClass should preserve Record as Object in runtime prop constructors. Got:\n{}",
+            code
+        );
     }
 
     #[test]
@@ -657,6 +734,10 @@ function handleClick(e: MouseEvent) {
             result.code.contains("emits:"),
             "Should have emits definition"
         );
+        assert!(
+            result.code.contains(r#"emits: ["click", "update"]"#),
+            "Should preserve event names in emits array"
+        );
     }
 
     #[test]
@@ -677,6 +758,52 @@ const emit = defineEmits<(e: 'click') => void>()
         assert!(
             result.code.contains("const emit = __emit"),
             "Should bind emit to __emit"
+        );
+        assert!(
+            result.code.contains(r#"emits: ["click"]"#),
+            "Should preserve the single event name in emits array"
+        );
+    }
+
+    #[test]
+    fn test_compile_script_setup_with_function_typed_define_emits_keeps_event_names() {
+        let content = r#"
+const emit = defineEmits<{
+  (_: 'updateNodes', nodes: NodeState[], key: keyof NodeStyle, values: string[], options?: { isStaged?: boolean }): void
+  (_: 'updateAttrs', nodes: NodeState[], styles: Partial<NodeStyle>[], options?: { isStaged?: boolean }): void
+  (_: 'changePanelTab', panelTab: 'motion' | 'box'): void
+  (_: 'toggleAssetPicker', isOpen: boolean | { update: (src: string) => void; confirm: () => void }): void
+  (_: 'togglePreview', isOpen: boolean, withPoster?: boolean): void
+  (_: 'toggleGlyphPicker', isOpen: boolean): void
+  (_: 'cancel'): void
+  (_: 'confirm'): void
+  (_: 'appendItem'): void
+  (_: 'appendProperty'): void
+}>()
+"#;
+        let result = compile_script_setup(content, "Test", false, true, None).unwrap();
+
+        println!("Function-typed defineEmits output:\n{}", result.code);
+
+        assert!(
+            result.code.contains(r#""updateNodes""#)
+                && result.code.contains(r#""updateAttrs""#)
+                && result.code.contains(r#""changePanelTab""#)
+                && result.code.contains(r#""toggleAssetPicker""#)
+                && result.code.contains(r#""togglePreview""#)
+                && result.code.contains(r#""toggleGlyphPicker""#)
+                && result.code.contains(r#""cancel""#)
+                && result.code.contains(r#""confirm""#)
+                && result.code.contains(r#""appendItem""#)
+                && result.code.contains(r#""appendProperty""#),
+            "Should preserve defineEmits call signature event names"
+        );
+        assert!(
+            !result.code.contains(r#""e""#)
+                && !result.code.contains(r#""doms""#)
+                && !result.code.contains(r#""values""#)
+                && !result.code.contains(r#""options""#),
+            "Should not emit call signature parameter names"
         );
     }
 

--- a/crates/vize_atelier_sfc/src/script/context/helpers.rs
+++ b/crates/vize_atelier_sfc/src/script/context/helpers.rs
@@ -2,7 +2,7 @@
 //!
 //! Free functions used by the parsing and props extraction logic.
 
-use oxc_ast::ast::{CallExpression, Expression, ImportDeclaration, VariableDeclarationKind};
+use oxc_ast::ast::{Argument, CallExpression, Expression, ImportDeclaration, VariableDeclarationKind};
 use oxc_span::GetSpan;
 
 use crate::types::BindingType;
@@ -42,9 +42,13 @@ pub(super) fn extract_macro_from_expr(
 pub(super) fn infer_binding_type(
     init: &Expression<'_>,
     kind: VariableDeclarationKind,
+    source: &str,
 ) -> BindingType {
     // Check for macro calls
     if let Expression::CallExpression(call) = init {
+        if let Some(binding_type) = infer_inject_binding_type(call, source) {
+            return binding_type;
+        }
         if let Some(name) = get_callee_name(call) {
             match name.as_str() {
                 // defineProps binding is the props OBJECT, not a prop - treat as SetupReactiveConst
@@ -93,6 +97,43 @@ pub(super) fn infer_binding_type(
             BindingType::SetupConst
         }
     }
+}
+
+fn infer_inject_binding_type(call: &CallExpression<'_>, source: &str) -> Option<BindingType> {
+    if !is_call_of(call, "inject") {
+        return None;
+    }
+
+    if let Some(type_args) = &call.type_arguments {
+        let start = type_args.span.start as usize;
+        let end = type_args.span.end as usize;
+        if start < end && end <= source.len() {
+            let normalized: std::string::String = source[start..end]
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect();
+            if normalized.contains("Ref<")
+                || normalized.contains("ShallowRef<")
+                || normalized.contains("ComputedRef<")
+                || normalized.contains("WritableComputedRef<")
+            {
+                return Some(BindingType::SetupMaybeRef);
+            }
+        }
+    }
+
+    if let Some(Argument::CallExpression(inner_call)) = call.arguments.get(1) {
+        if let Some(name) = get_callee_name(inner_call) {
+            match name.as_str() {
+                "ref" | "shallowRef" | "customRef" | "toRef" | "computed" => {
+                    return Some(BindingType::SetupMaybeRef);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    None
 }
 
 /// Get callee name from call expression

--- a/crates/vize_atelier_sfc/src/script/context/mod.rs
+++ b/crates/vize_atelier_sfc/src/script/context/mod.rs
@@ -261,6 +261,27 @@ function increment() { count.value++ }
     }
 
     #[test]
+    fn test_inject_ref_binding_is_maybe_ref() {
+        let content = r#"
+import { inject, ref, type Ref } from 'vue'
+
+const selectedView = inject<Ref<'all' | 'draft'>>('selectedView', ref('all'))
+const panelState = inject<Ref<'closing' | 'opening'>>('panelState')
+"#;
+        let mut ctx = ScriptCompileContext::new(content);
+        ctx.analyze();
+
+        assert_eq!(
+            ctx.bindings.bindings.get("selectedView"),
+            Some(&BindingType::SetupMaybeRef)
+        );
+        assert_eq!(
+            ctx.bindings.bindings.get("panelState"),
+            Some(&BindingType::SetupMaybeRef)
+        );
+    }
+
+    #[test]
     fn test_props_destructure() {
         let content = r#"const { foo, bar } = defineProps<{ foo: string, bar: number }>()"#;
         let mut ctx = ScriptCompileContext::new(content);
@@ -424,6 +445,20 @@ const props = withDefaults(defineProps<Props>(), {
         assert_eq!(
             ctx.bindings.bindings.get("count"),
             Some(&BindingType::Props)
+        );
+    }
+
+    #[test]
+    fn test_object_destructure_from_composable_registers_bindings() {
+        let content = r#"
+const { format } = useFormatter(catalog)
+"#;
+        let mut ctx = ScriptCompileContext::new(content);
+        ctx.analyze();
+
+        assert_eq!(
+            ctx.bindings.bindings.get("format"),
+            Some(&BindingType::SetupMaybeRef)
         );
     }
 }

--- a/crates/vize_atelier_sfc/src/script/context/parse.rs
+++ b/crates/vize_atelier_sfc/src/script/context/parse.rs
@@ -258,7 +258,7 @@ impl ScriptCompileContext {
 
                             // Determine binding type
                             let binding_type = if let Some(init) = &decl.init {
-                                infer_binding_type(init, var_decl.kind)
+                                infer_binding_type(init, var_decl.kind, source)
                             } else {
                                 match var_decl.kind {
                                     VariableDeclarationKind::Const => BindingType::SetupConst,
@@ -315,7 +315,7 @@ impl ScriptCompileContext {
                                 // non-destructured declarations. This ensures _unref() is
                                 // applied in templates for composable returns.
                                 let destructure_type = if let Some(init) = &decl.init {
-                                    infer_binding_type(init, var_decl.kind)
+                                    infer_binding_type(init, var_decl.kind, source)
                                 } else {
                                     match var_decl.kind {
                                         VariableDeclarationKind::Const => BindingType::SetupConst,
@@ -333,7 +333,7 @@ impl ScriptCompileContext {
                         }
                         BindingPattern::ArrayPattern(arr_pat) => {
                             let destructure_type = if let Some(init) = &decl.init {
-                                infer_binding_type(init, var_decl.kind)
+                                infer_binding_type(init, var_decl.kind, source)
                             } else {
                                 match var_decl.kind {
                                     VariableDeclarationKind::Const => BindingType::SetupConst,

--- a/crates/vize_atelier_sfc/src/script/context/props.rs
+++ b/crates/vize_atelier_sfc/src/script/context/props.rs
@@ -90,21 +90,35 @@ impl ScriptCompileContext {
         let mut depth = 0;
         let mut current = vize_carton::String::default();
 
-        for c in resolved_content.chars() {
+        let chars: Vec<char> = resolved_content.chars().collect();
+        for (i, c) in chars.iter().enumerate() {
             match c {
                 '{' | '<' | '(' | '[' => {
                     depth += 1;
-                    current.push(c);
+                    current.push(*c);
                 }
-                '}' | '>' | ')' | ']' => {
-                    depth -= 1;
-                    current.push(c);
+                '>' => {
+                    // Don't treat the arrow in function types (`=>`) as a closing bracket.
+                    if i > 0 && chars[i - 1] == '=' {
+                        current.push(*c);
+                    } else {
+                        if depth > 0 {
+                            depth -= 1;
+                        }
+                        current.push(*c);
+                    }
+                }
+                '}' | ')' | ']' => {
+                    if depth > 0 {
+                        depth -= 1;
+                    }
+                    current.push(*c);
                 }
                 ',' | ';' | '\n' if depth == 0 => {
                     self.extract_single_prop_from_type(&current);
                     current.clear();
                 }
-                _ => current.push(c),
+                _ => current.push(*c),
             }
         }
         self.extract_single_prop_from_type(&current);

--- a/crates/vize_atelier_vapor/src/generate/operations.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations.rs
@@ -786,7 +786,7 @@ fn generate_component_props_str(
                     ["() => (\"", first.content.as_str(), "\")"].concat().into()
                 } else if is_event {
                     let resolved = ctx.resolve_expression(first.content.as_str());
-                    ["() => ", &resolved].concat().into()
+                    resolved
                 } else {
                     let resolved = ctx.resolve_expression(first.content.as_str());
                     ["() => (", &resolved, ")"].concat().into()

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -350,6 +350,34 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_component_event_listener_not_wrapped_in_getter() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<Child @selectItem="(value) => emit('selectItem', value)" />"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+
+        let code = normalize_code(&result.code);
+        assert!(
+            code.contains("onSelectItem: (value) => _ctx.emit('selectItem', value)"),
+            "Should pass component listener as direct handler: {}",
+            code
+        );
+        assert!(
+            !code.contains("onSelectItem: () => (value) => _ctx.emit('selectItem', value)"),
+            "Should not wrap component listener in getter: {}",
+            code
+        );
+    }
+
+    #[test]
     fn test_compile_branch_component_under_existing_parent() {
         let allocator = Bump::new();
         let result = compile_vapor(

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -24,16 +24,20 @@ export function extractStyleBlocks(source: string): StyleBlockInfo[] {
   const blocks: StyleBlockInfo[] = [];
   const styleRegex = /<style([^>]*)>([\s\S]*?)<\/style>/gi;
   let match;
-  let index = 0;
   while ((match = styleRegex.exec(source)) !== null) {
     const attrs = match[1];
     const content = match[2];
+    const hasSrc = /\bsrc=["'][^"']+["']/.test(attrs);
+    // Keep parity with vue/compiler-sfc descriptor indexing:
+    // empty inline <style> blocks are dropped and do not consume indices.
+    if (!hasSrc && content.trim().length === 0) {
+      continue;
+    }
     const lang = attrs.match(/\blang=["']([^"']+)["']/)?.[1] ?? null;
     const scoped = /\bscoped\b/.test(attrs);
     const moduleMatch = attrs.match(/\bmodule(?:=["']([^"']+)["'])?/);
     const isModule = moduleMatch ? moduleMatch[1] || true : false;
-    blocks.push({ content, lang, scoped, module: isModule, index });
-    index++;
+    blocks.push({ content, lang, scoped, module: isModule, index: blocks.length });
   }
   return blocks;
 }

--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -2,10 +2,16 @@ import type { Plugin, TransformResult } from "vite";
 import { transformWithOxc } from "vite";
 import { createRequire } from "node:module";
 
-import { getCompileOptionsForRequest, getEnvironmentCache, type VizePluginState } from "./state.js";
+import type { VizePluginState } from "./state.js";
 import { compileFile } from "../compiler.js";
 import { generateOutput } from "../utils/index.js";
 import { applyDefineReplacements } from "../transform.js";
+
+function looksLikeSfcSource(code: string): boolean {
+  const trimmed = code.trimStart();
+  if (!trimmed.startsWith("<")) return false;
+  return /^(?:<!--[\s\S]*?-->\s*)*<(template|script|style)\b/i.test(trimmed);
+}
 
 export function createVueCompatPlugin(state: VizePluginState): Plugin {
   let compilerSfc: unknown = null;
@@ -51,15 +57,19 @@ export function createPostTransformPlugin(state: VizePluginState): Plugin {
         !id.endsWith(".vue.ts") &&
         !id.includes("node_modules") &&
         id.endsWith(".setup.ts") &&
+        looksLikeSfcSource(code) &&
         /<script\s+setup[\s>]/.test(code)
       ) {
         state.logger.log(`post-transform: compiling virtual SFC content from ${id}`);
         try {
-          const isSsr = !!transformOptions?.ssr;
           const compiled = compileFile(
             id,
-            getEnvironmentCache(state, isSsr),
-            getCompileOptionsForRequest(state, isSsr),
+            state.cache,
+            {
+              sourceMap: state.mergedOptions?.sourceMap ?? !(state.isProduction ?? false),
+              ssr: state.mergedOptions?.ssr ?? false,
+              vapor: state.mergedOptions?.vapor ?? false,
+            },
             code,
           );
 

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -82,6 +82,7 @@ export default _sfc_main`,
 
 const firstLoad = loadHook(hmrState, toVirtualId(realPath), { ssr: false });
 assert.ok(firstLoad && typeof firstLoad === "object", "Virtual module should load as code object");
+assert.equal(firstLoad.moduleType, "js", "Virtual modules should be marked as JS for Vite 8");
 assert.match(
   firstLoad.code,
   /__hmrUpdateType = "template-only"/,
@@ -132,6 +133,11 @@ assert.ok(
   inlineLoad && typeof inlineLoad === "object",
   "Inline-template virtual modules should load as code objects",
 );
+assert.equal(
+  inlineLoad.moduleType,
+  "js",
+  "Inline-template virtual modules should be marked as JS for Vite 8",
+);
 assert.match(
   inlineLoad.code,
   /__hmrUpdateType = "full-reload"/,
@@ -171,6 +177,11 @@ assert.ok(
   clientEnvironmentLoad && typeof clientEnvironmentLoad === "object",
   "Client environment loads should succeed",
 );
+assert.equal(
+  clientEnvironmentLoad.moduleType,
+  "js",
+  "Client virtual modules should be marked as JS for Vite 8",
+);
 assert.match(
   clientEnvironmentLoad.code,
   /ClientCompiled/,
@@ -182,10 +193,66 @@ assert.ok(
   ssrEnvironmentLoad && typeof ssrEnvironmentLoad === "object",
   "SSR environment loads should succeed",
 );
+assert.equal(
+  ssrEnvironmentLoad.moduleType,
+  "js",
+  "SSR virtual modules should be marked as JS for Vite 8",
+);
 assert.match(
   ssrEnvironmentLoad.code,
   /ServerCompiled/,
   "SSR loads should read from the SSR compilation cache",
+);
+
+const assetUrlPath = "/src/components/common/BrandLogo.vue";
+const assetUrlState: VizePluginState = {
+  ...hmrState,
+  root: "/src",
+  cache: new Map([
+    [
+      assetUrlPath,
+      {
+        code: `export default {
+  __name: "BrandLogo",
+  setup() {
+    const getIcon = (name, theme) => new URL(\`../../assets/logos/brand_\${name}_\${theme}.svg\`, import.meta.url).href;
+    return { getIcon };
+  }
+}`,
+        scopeId: "asset1234",
+        hasScoped: false,
+        styles: [],
+      },
+    ],
+  ]),
+  ssrCache: new Map(),
+  pendingHmrUpdateTypes: new Map(),
+};
+
+const assetUrlLoad = loadHook(assetUrlState, toVirtualId(assetUrlPath), { ssr: false });
+assert.ok(
+  assetUrlLoad && typeof assetUrlLoad === "object",
+  "Virtual modules with dynamic asset URLs should still load as code objects",
+);
+assert.equal(
+  assetUrlLoad.moduleType,
+  "js",
+  "Dynamic asset URL virtual modules should be marked as JS for Vite 8",
+);
+assert.match(
+  assetUrlLoad.code,
+  /import\.meta\.glob\("\/assets\/logos\/brand_\*_\*\.svg", \{"eager":true,"import":"default","query":"\?url"\}\)/,
+  "Dynamic new URL(import.meta.url) expressions should be rewritten to a root-absolute import.meta.glob",
+);
+assert.match(
+  assetUrlLoad.code,
+  /`\/assets\/logos\/brand_\$\{name\}_\$\{theme\}\.svg`/,
+  "Rewritten dynamic asset URLs should use a root-absolute lookup key",
+);
+assert.doesNotMatch(
+  assetUrlLoad.code,
+  /new URL\(`\.\.\/\.\.\/assets\/logos/,
+  "Original relative dynamic new URL(import.meta.url) expression should be rewritten away",
 );
 
 console.log("✅ vite-plugin-vize load boundary tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -16,7 +16,11 @@ import {
   RESOLVED_CSS_MODULE,
   rewriteDynamicTemplateImports,
 } from "../virtual.js";
-import { rewriteStaticAssetUrls, applyDefineReplacements } from "../transform.js";
+import {
+  rewriteStaticAssetUrls,
+  rewriteDynamicAssetImportMetaUrls,
+  applyDefineReplacements,
+} from "../transform.js";
 
 const SERVER_PLACEHOLDER_CODE = `import { createElementBlock, defineComponent } from "vue";
 export default defineComponent({
@@ -26,6 +30,20 @@ export default defineComponent({
   }
 });
 `;
+
+type JsModuleLoadResult = {
+  code: string;
+  map: null;
+  moduleType: "js";
+};
+
+function asJsModule(code: string): JsModuleLoadResult {
+  return {
+    code,
+    map: null,
+    moduleType: "js",
+  };
+}
 
 export function getBoundaryPlaceholderCode(realPath: string, ssr: boolean): string | null {
   if (ssr && realPath.endsWith(".client.vue")) {
@@ -43,11 +61,16 @@ function getOxcDumpPath(root: string, realPath: string): string {
   return path.join(dumpDir, `vize-oxc-error-${path.basename(realPath)}.ts`);
 }
 
+function hasRelativeImportMetaGlob(code: string): boolean {
+  return /import\.meta\.glob\(\s*(['"`])(?:\.\/|\.\.\/)/.test(code);
+}
+
+
 export function loadHook(
   state: VizePluginState,
   id: string,
   loadOptions?: { ssr?: boolean },
-): string | { code: string; map: null } | null {
+): string | { code: string; map: null } | JsModuleLoadResult | null {
   // Pick the correct viteBase for URL resolution based on the build environment.
   const currentBase = loadOptions?.ssr ? state.serverViteBase : state.clientViteBase;
 
@@ -135,13 +158,10 @@ export function loadHook(
       const setupMatch = source.match(/<script\s+setup[^>]*>([\s\S]*?)<\/script>/);
       if (setupMatch) {
         const scriptContent = setupMatch[1];
-        return {
-          code: `${scriptContent}\nexport default {}`,
-          map: null,
-        };
+        return asJsModule(`${scriptContent}\nexport default {}`);
       }
     }
-    return { code: "export default {}", map: null };
+    return asJsModule("export default {}");
   }
 
   // Handle vize virtual modules
@@ -157,10 +177,7 @@ export function loadHook(
     const placeholderCode = getBoundaryPlaceholderCode(realPath, !!loadOptions?.ssr);
     if (placeholderCode) {
       state.logger.log(`load: using boundary placeholder for ${realPath}`);
-      return {
-        code: placeholderCode,
-        map: null,
-      };
+      return asJsModule(placeholderCode);
     }
 
     const cache = getEnvironmentCache(state, isSsr);
@@ -191,24 +208,28 @@ export function loadHook(
       }
       const output = rewriteStaticAssetUrls(
         rewriteDynamicTemplateImports(
-          generateOutput(compiled, {
-            isProduction: state.isProduction,
-            isDev: state.server !== null && !isSsr,
-            hmrUpdateType: pendingHmrUpdateType,
-            extractCss: state.extractCss,
-            filePath: realPath,
-          }),
+          rewriteDynamicAssetImportMetaUrls(
+            generateOutput(compiled, {
+              isProduction: state.isProduction,
+              isDev: state.server !== null && !isSsr,
+              hmrUpdateType: pendingHmrUpdateType,
+              extractCss: state.extractCss,
+              filePath: realPath,
+            }),
+            realPath,
+            state.root,
+          ),
           state.dynamicImportAliasRules,
         ),
         state.dynamicImportAliasRules,
       );
+      if (hasRelativeImportMetaGlob(output)) {
+        state.logger.warn(`load: virtual module for ${realPath} still contains import.meta.glob`);
+      }
       if (!loadOptions?.ssr) {
         state.pendingHmrUpdateTypes.delete(realPath);
       }
-      return {
-        code: output,
-        map: null,
-      };
+      return asJsModule(output);
     }
   }
 
@@ -229,7 +250,9 @@ export function loadHook(
           ? `${pathToFileURL(fsPath).href}${querySuffix}`
           : "/@fs" + fsPath + querySuffix;
       state.logger.log(`load: proxying \0-prefixed file ${id} -> re-export from ${importPath}`);
-      return `export { default } from ${JSON.stringify(importPath)};\nexport * from ${JSON.stringify(importPath)};`;
+      return asJsModule(
+        `export { default } from ${JSON.stringify(importPath)};\nexport * from ${JSON.stringify(importPath)};`,
+      );
     }
   }
 
@@ -256,7 +279,11 @@ export async function transformHook(
         transformed = applyDefineReplacements(transformed, defines);
       }
 
-      return { code: transformed, map: result.map as TransformResult["map"] };
+      return {
+        code: transformed,
+        map: result.map as TransformResult["map"],
+        moduleType: "js",
+      };
     } catch (e: unknown) {
       state.logger.error(`transformWithOxc failed for ${realPath}:`, e);
       const dumpPath = getOxcDumpPath(state.root, realPath);

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -11,6 +11,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const workspaceRoot = path.resolve(__dirname, "../../../..");
 
+function hasFixtureFile(projectRoot: string, relativePath: string): boolean {
+  return fs.existsSync(path.join(projectRoot, relativePath));
+}
+
+function skipMissingFixture(projectRoot: string, relativePath: string): boolean {
+  if (hasFixtureFile(projectRoot, relativePath)) {
+    return false;
+  }
+
+  console.warn(
+    `skipping resolve fixture ${path.basename(projectRoot)}: missing ${relativePath} (git submodule not initialized)`,
+  );
+  return true;
+}
+
 function createState(root: string): VizePluginState {
   return {
     cache: new Map(),
@@ -61,21 +76,23 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
 {
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
-  const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));
-  const resolved = await resolveIdHook(
-    nullResolveContext,
-    createState(projectRoot),
-    "vue-data-ui/style.css",
-    importer,
-    undefined,
-  );
+  if (!skipMissingFixture(projectRoot, path.join("app", "pages", "index.vue"))) {
+    const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));
+    const resolved = await resolveIdHook(
+      nullResolveContext,
+      createState(projectRoot),
+      "vue-data-ui/style.css",
+      importer,
+      undefined,
+    );
 
-  assert.match(expectResolvedId(resolved), /vue-data-ui\/dist\/style\.css$/);
+    assert.match(expectResolvedId(resolved), /vue-data-ui\/dist\/style\.css$/);
+  }
 }
 
 {
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "vuefes-2025");
-  if (fs.existsSync(path.join(projectRoot, "package.json"))) {
+  if (!skipMissingFixture(projectRoot, "package.json")) {
     const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));
     const resolved = await resolveIdHook(
       nullResolveContext,
@@ -94,37 +111,70 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
 {
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
-  const source = path.join(projectRoot, "app", "pages", "index.vue");
-  const resolved = await resolveIdHook(
-    nullResolveContext,
-    createState(projectRoot),
-    source,
-    undefined,
-    { isEntry: true, ssr: true },
-  );
+  if (!skipMissingFixture(projectRoot, path.join("app", "pages", "index.vue"))) {
+    const source = path.join(projectRoot, "app", "pages", "index.vue");
+    const resolved = await resolveIdHook(
+      nullResolveContext,
+      createState(projectRoot),
+      source,
+      undefined,
+      { isEntry: true, ssr: true },
+    );
+
+    assert.equal(
+      expectResolvedId(resolved),
+      toVirtualId(source, true),
+      "SSR resolves should use a dedicated virtual module ID",
+    );
+  }
+}
+
+{
+  const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
+  if (!skipMissingFixture(projectRoot, path.join("app", "pages", "index.vue"))) {
+    const source = path.join(projectRoot, "app", "pages", "index.vue");
+    const resolved = await resolveIdHook(
+      nullResolveContext,
+      createState(projectRoot),
+      toVirtualId(source),
+      undefined,
+      { isEntry: false, ssr: true },
+    );
+
+    assert.equal(
+      expectResolvedId(resolved),
+      toVirtualId(source, true),
+      "SSR resolution should upgrade client virtual IDs to SSR-specific virtual IDs",
+    );
+  }
+}
+
+{
+  const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
+  const buildState = {
+    ...createState(projectRoot),
+    server: null,
+  };
+  const styleRequest = `${path.join(projectRoot, "app", "pages", "index.vue")}?vue&type=style&index=0&lang=scss`;
+  const resolved = await resolveIdHook(nullResolveContext, buildState, styleRequest, undefined, {});
 
   assert.equal(
     expectResolvedId(resolved),
-    toVirtualId(source, true),
-    "SSR resolves should use a dedicated virtual module ID",
+    `${styleRequest}.scss`,
+    "Build style requests should stay null-byte-free so @vitejs/plugin-vue can read the descriptor",
   );
 }
 
 {
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
-  const source = path.join(projectRoot, "app", "pages", "index.vue");
-  const resolved = await resolveIdHook(
-    nullResolveContext,
-    createState(projectRoot),
-    toVirtualId(source),
-    undefined,
-    { isEntry: false, ssr: true },
-  );
+  const devState = createState(projectRoot);
+  const styleRequest = `${path.join(projectRoot, "app", "pages", "index.vue")}?vue&type=style&index=0&lang=scss`;
+  const resolved = await resolveIdHook(nullResolveContext, devState, styleRequest, undefined, {});
 
   assert.equal(
     expectResolvedId(resolved),
-    toVirtualId(source, true),
-    "SSR resolution should upgrade client virtual IDs to SSR-specific virtual IDs",
+    `\0${styleRequest}.scss`,
+    "Dev style requests should keep the virtual-module prefix for the CSS pipeline",
   );
 }
 

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -104,6 +104,11 @@ export async function resolveIdHook(
   const isBuild = state.server === null;
   const isSsrRequest = !!options?.ssr || (importer ? isVizeSsrVirtual(importer) : false);
 
+  const makeStyleRequestId = (requestId: string, lang: string, isModule: boolean): string => {
+    const suffix = isModule ? `.module.${lang}` : `.${lang}`;
+    return isBuild ? `${requestId}${suffix}` : `\0${requestId}${suffix}`;
+  };
+
   // Skip all virtual module IDs
   if (id.startsWith("\0")) {
     // This is one of our .vue.ts virtual modules -- pass through
@@ -184,11 +189,11 @@ export async function resolveIdHook(
     if (params.has("module")) {
       // For CSS Modules, append .module.{lang} suffix so Vite's CSS pipeline
       // automatically treats it as a CSS module and returns the class mapping.
-      return `\0${id}.module.${lang}`;
+      return makeStyleRequestId(id, lang, true);
     }
     // Append .{lang} suffix so Vite's CSS pipeline recognizes the file type
     // and applies the appropriate preprocessor (SCSS, Less, etc.).
-    return `\0${id}.${lang}`;
+    return makeStyleRequestId(id, lang, false);
   }
 
   // If importer is a vize virtual module or macro module, resolve imports against the real path

--- a/npm/vite-plugin-vize/src/transform.ts
+++ b/npm/vite-plugin-vize/src/transform.ts
@@ -5,6 +5,8 @@
  * provides the debug logger.
  */
 
+import path from "node:path";
+
 import { escapeRegExp, type DynamicImportAliasRule } from "./virtual.js";
 
 /**
@@ -17,6 +19,10 @@ import { escapeRegExp, type DynamicImportAliasRule } from "./virtual.js";
 // File extensions that are code modules, not static assets.
 // These should never be rewritten to default imports by rewriteStaticAssetUrls.
 const SCRIPT_EXTENSIONS = /\.(js|mjs|cjs|ts|mts|cts|jsx|tsx)$/i;
+
+type TemplatePart =
+  | { type: "static"; value: string }
+  | { type: "expr"; value: string };
 
 export function rewriteStaticAssetUrls(code: string, aliasRules: DynamicImportAliasRule[]): string {
   let rewritten = code;
@@ -50,6 +56,134 @@ export function rewriteStaticAssetUrls(code: string, aliasRules: DynamicImportAl
     rewritten = imports.join("\n") + "\n" + rewritten;
   }
   return rewritten;
+}
+
+function splitTemplateLiteralParts(raw: string): TemplatePart[] | null {
+  const parts: TemplatePart[] = [];
+  let cursor = 0;
+
+  while (cursor < raw.length) {
+    const exprStart = raw.indexOf("${", cursor);
+    if (exprStart === -1) {
+      if (cursor < raw.length) {
+        parts.push({ type: "static", value: raw.slice(cursor) });
+      }
+      return parts;
+    }
+
+    if (exprStart > cursor) {
+      parts.push({ type: "static", value: raw.slice(cursor, exprStart) });
+    }
+
+    let depth = 1;
+    let index = exprStart + 2;
+    while (index < raw.length && depth > 0) {
+      const char = raw[index];
+      if (char === "{") {
+        depth += 1;
+      } else if (char === "}") {
+        depth -= 1;
+      }
+      index += 1;
+    }
+
+    if (depth !== 0) {
+      return null;
+    }
+
+    parts.push({ type: "expr", value: raw.slice(exprStart + 2, index - 1) });
+    cursor = index;
+  }
+
+  return parts;
+}
+
+function toBrowserGlobPath(resolvedPath: string, root: string): string {
+  const normalizedRoot = path.resolve(root).replace(/\\/g, "/");
+  const normalizedPath = path.resolve(resolvedPath).replace(/\\/g, "/");
+  if (normalizedPath.startsWith(normalizedRoot + "/")) {
+    return "/" + path.posix.relative(normalizedRoot, normalizedPath);
+  }
+  return `/@fs${normalizedPath}`;
+}
+
+function buildResolvedTemplateLiteral(
+  parts: TemplatePart[],
+  realPath: string,
+  root: string,
+): { pattern: string; key: string } | null {
+  const firstStatic = parts.find((part): part is { type: "static"; value: string } => part.type === "static");
+  if (!firstStatic) {
+    return null;
+  }
+  if (!firstStatic.value.startsWith("./") && !firstStatic.value.startsWith("../")) {
+    return null;
+  }
+
+  const slashIndex = firstStatic.value.lastIndexOf("/");
+  const relativeDir = slashIndex >= 0 ? firstStatic.value.slice(0, slashIndex + 1) : "./";
+  const firstStaticRemainder = slashIndex >= 0 ? firstStatic.value.slice(slashIndex + 1) : firstStatic.value;
+
+  const importerDir = path.dirname(realPath);
+  const resolvedDir = toBrowserGlobPath(path.resolve(importerDir, relativeDir), root).replace(/\/$/, "");
+  let patternSuffix = firstStaticRemainder;
+  let keySuffix = firstStaticRemainder;
+  let consumedFirstStatic = false;
+
+  for (const part of parts) {
+    if (part.type === "static") {
+      if (!consumedFirstStatic) {
+        consumedFirstStatic = true;
+        continue;
+      }
+      patternSuffix += part.value;
+      keySuffix += part.value;
+      continue;
+    }
+
+    patternSuffix += "*";
+    keySuffix += `\${${part.value}}`;
+  }
+
+  patternSuffix = patternSuffix.replace(/\*{2,}/g, "*");
+  return {
+    pattern: `${resolvedDir}/${patternSuffix}`,
+    key: `${resolvedDir}/${keySuffix}`,
+  };
+}
+
+export function rewriteDynamicAssetImportMetaUrls(
+  code: string,
+  realPath: string,
+  root: string,
+): string {
+  return code.replace(
+    /\bnew\s+URL\s*\(\s*`([^`$\\]*(?:\\.[^`$\\]*)*(?:\$\{[\s\S]*?\}[^`$\\]*(?:\\.[^`$\\]*)*)+)`\s*,\s*import\.meta\.url\s*\)/g,
+    (match, rawTemplate: string) => {
+      const parts = splitTemplateLiteralParts(rawTemplate);
+      if (!parts) {
+        return match;
+      }
+
+      const resolved = buildResolvedTemplateLiteral(parts, realPath, root);
+      if (!resolved) {
+        return match;
+      }
+
+      const globOptions = JSON.stringify({
+        eager: true,
+        import: "default",
+        query: "?url",
+      });
+      return (
+        `new URL((import.meta.glob(${JSON.stringify(resolved.pattern)}, ${globOptions}))[` +
+        "`" +
+        `${resolved.key}` +
+        "`" +
+        `], import.meta.url)`
+      );
+    },
+  );
 }
 
 /**

--- a/npm/vize-native/package.json
+++ b/npm/vize-native/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "vize-vitrine.*.node"
   ],
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/fixtures/sfc/patches.toml
+++ b/tests/fixtures/sfc/patches.toml
@@ -149,6 +149,26 @@ import Layout from './Layout.vue'
 """
 
 # =============================================================================
+# Dynamic asset URL with import.meta.url in virtual modules
+# Issue: Vite rewrites dynamic new URL(..., import.meta.url) to import.meta.glob,
+# which becomes a relative glob inside Vize virtual modules and crashes Rolldown.
+# =============================================================================
+
+[[cases]]
+name = "dynamic asset URL with import meta url"
+input = """
+<script setup>
+const getBrandLogoUrl = (type, theme) => {
+  return new URL(`../../assets/logos/brand_${type}_${theme}.svg`, import.meta.url).href
+}
+</script>
+
+<template>
+  <img :src="getBrandLogoUrl('alpha', 'light')" alt="brand logo" />
+</template>
+"""
+
+# =============================================================================
 # v-if duplicate event handlers (v_if.rs)
 # Issue: v-model transform generated duplicate event handlers
 # Fix: Use HashSet to filter duplicate events
@@ -200,6 +220,45 @@ const showing = ref(false)
 """
 
 [[cases]]
+name = "dynamic slot outlet name in loop"
+input = """
+<script setup>
+const tabs = [
+  { key: 'basic', label: 'Basic' },
+  { key: 'parts', label: 'Parts' },
+]
+</script>
+
+<template>
+  <div>
+    <template v-for="tab in tabs" :key="tab.key">
+      <slot :name="tab.key" :tab="tab" />
+    </template>
+  </div>
+</template>
+"""
+
+[[cases]]
+name = "v for template else interpolation wraps text vnode"
+input = """
+<script setup>
+function splitByQuery(name) {
+  return [{ text: name, match: false }]
+}
+const name = 'paper'
+</script>
+
+<template>
+  <p>
+    <template v-for="(seg, i) in splitByQuery(name)" :key="i">
+      <mark v-if="seg.match">{{ seg.text }}</mark>
+      <template v-else>{{ seg.text }}</template>
+    </template>
+  </p>
+</template>
+"""
+
+[[cases]]
 name = "v-if with custom directive on element"
 input = """
 <script setup>
@@ -210,6 +269,18 @@ const helpText = ref('Help')
 
 <template>
   <button v-if="showHelp" v-tooltip.noDelay="helpText">Help</button>
+</template>
+"""
+
+[[cases]]
+name = "imported custom directive binding in script setup"
+input = """
+<script setup lang="ts">
+import { vElementHover } from '@vueuse/components'
+</script>
+
+<template>
+  <div v-element-hover="() => {}" />
 </template>
 """
 
@@ -272,6 +343,75 @@ const iconProps = { size: 24, color: 'blue' }
   <Icon v-if="mode === 'view'" name="eye" />
   <Icon v-else-if="mode === 'edit'" v-bind="iconProps" name="pencil" />
   <Icon v-else name="default" />
+</template>
+"""
+
+[[cases]]
+name = "v if branch keeps maybe ref style patch flag"
+input = """
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const show = ref(true)
+const floatingStyles = ref({ left: '10px', top: '20px' })
+</script>
+
+<template>
+  <div v-if="show" :style="floatingStyles"></div>
+</template>
+"""
+
+[[cases]]
+name = "template ref with dynamic props in v if branch"
+input = """
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+const reference = ref<HTMLElement>()
+const floating = ref<HTMLElement>()
+const isOpen = ref(true)
+const klass = computed(() => 'x')
+const styles = computed(() => ({ left: '0px', top: '0px' }))
+function toggle() {}
+</script>
+
+<template>
+  <button
+    v-if="isOpen"
+    ref="reference"
+    :id="isOpen ? 'open' : undefined"
+    class="base"
+    :class="klass"
+    @click="toggle"
+  >
+    open
+  </button>
+  <div
+    v-if="isOpen"
+    ref="floating"
+    :style="styles"
+  >
+    panel
+  </div>
+</template>
+"""
+
+[[cases]]
+name = "options api dynamic style and class keep patch flags"
+input = """
+<script>
+export default {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+</script>
+
+<template>
+  <div class="map">
+    <div :style="knobStyle" :class="{ dragging }"></div>
+  </div>
 </template>
 """
 
@@ -678,6 +818,73 @@ const items: Item[] = []
   <div>
     {{ items.map((item: Item) => item.name).join(', ') }}
   </div>
+</template>
+"""
+
+[[cases]]
+name = "component event member expression handler is invoked"
+input = """
+<script setup>
+const actionHandler = useActionHandler()
+</script>
+
+<template>
+  <ActionPanel @selectItem="actionHandler.selectItem" />
+</template>
+"""
+
+[[cases]]
+name = "component event rest params stay local"
+input = """
+<script setup>
+const emit = defineEmits(['update'])
+</script>
+
+<template>
+  <Child
+    @update="(...$args) => emit('update', ...$args)"
+    @change="(...args) => emit('update', ...args)"
+  />
+</template>
+"""
+
+[[cases]]
+name = "function typed prop param does not shadow local t"
+input = """
+<script setup lang="ts">
+const { format } = useFormatter(catalog)
+const props = defineProps<{
+  renderLabel: (value: string, format: any) => string
+}>()
+</script>
+
+<template>
+  <PopupMenu>
+    <template #items="{ close }">
+      <OptionRow v-slot="{ active }">
+        <li :class="{ active }" @click="close()">
+          <span>{{ format('hello') }}</span>
+          <span>{{ renderLabel('x', format) }}</span>
+        </li>
+      </OptionRow>
+    </template>
+  </PopupMenu>
+</template>
+"""
+
+[[cases]]
+name = "nullable runtime prop types keep null"
+input = """
+<script setup lang="ts">
+defineProps<{
+  activeKey: string | null
+  items: string[] | null
+  groupName: string | null
+}>()
+</script>
+
+<template>
+  <div />
 </template>
 """
 

--- a/tests/snapshots/sfc/js/patches__component_event_member_expression_handler_is_invoked.snap
+++ b/tests/snapshots/sfc/js/patches__component_event_member_expression_handler_is_invoked.snap
@@ -1,0 +1,23 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { openBlock as _openBlock, createBlock as _createBlock, resolveComponent as _resolveComponent, unref as _unref } from "vue"
+
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const actionHandler = useActionHandler()
+
+return (_ctx, _cache) => {
+  const _component_ActionPanel = _resolveComponent("ActionPanel")
+
+  return (_openBlock(), _createBlock(_component_ActionPanel, {
+      onSelectItem: _cache[0] || (_cache[0] = (...args) => (_unref(actionHandler).selectItem && _unref(actionHandler).selectItem(...args)))
+    }))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__component_event_rest_params_stay_local.snap
+++ b/tests/snapshots/sfc/js/patches__component_event_rest_params_stay_local.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { openBlock as _openBlock, createBlock as _createBlock, resolveComponent as _resolveComponent, unref as _unref } from "vue"
+
+
+export default {
+  __name: 'test',
+  emits: ["update"],
+  setup(__props, { emit: __emit }) {
+
+const emit = __emit
+
+return (_ctx, _cache) => {
+  const _component_Child = _resolveComponent("Child")
+
+  return (_openBlock(), _createBlock(_component_Child, {
+      onUpdate: _cache[0] || (_cache[0] = (...$args) => _unref(emit)('update', ...$args)),
+      onChange: _cache[1] || (_cache[1] = (...args) => _unref(emit)('update', ...args))
+    }))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__dynamic_asset_url_with_import_meta_url.snap
+++ b/tests/snapshots/sfc/js/patches__dynamic_asset_url_with_import_meta_url.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const getBrandLogoUrl = (type, theme) => {
+  return new URL(`../../assets/logos/brand_${type}_${theme}.svg`, import.meta.url).href
+}
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("img", {
+      src: getBrandLogoUrl('alpha', 'light'),
+      alt: "brand logo"
+    }, null, 8 /* PROPS */, ["src"]))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__dynamic_slot_outlet_name_in_loop.snap
+++ b/tests/snapshots/sfc/js/patches__dynamic_slot_outlet_name_in_loop.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, renderList as _renderList, renderSlot as _renderSlot } from "vue"
+
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+const tabs = [
+  { key: 'basic', label: 'Basic' },
+  { key: 'parts', label: 'Parts' },
+]
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs, (tab) => {
+        return (_openBlock(), _createElementBlock(_Fragment, { key: tab.key }, [
+          _renderSlot(_ctx.$slots, tab.key, {tab: tab})
+        ], 64 /* STABLE_FRAGMENT */))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__function_typed_prop_param_does_not_shadow_local_t.snap
+++ b/tests/snapshots/sfc/js/patches__function_typed_prop_param_does_not_shadow_local_t.snap
@@ -1,0 +1,43 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, createVNode as _createVNode, createElementVNode as _createElementVNode, resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, withCtx as _withCtx, unref as _unref } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  props: {
+    renderLabel: { type: Function, required: true }
+  },
+  setup(__props: any) {
+
+const props = __props
+const { format } = useFormatter(catalog)
+
+return (_ctx: any,_cache: any) => {
+  const _component_OptionRow = _resolveComponent("OptionRow")
+  const _component_PopupMenu = _resolveComponent("PopupMenu")
+
+  return (_openBlock(), _createBlock(_component_PopupMenu, null, {
+      items: _withCtx(({ close }) => [
+        _createVNode(_component_OptionRow, null, {
+          default: _withCtx(({ active }) => [
+            _createElementVNode("li", {
+              class: _normalizeClass({ active: active }),
+              onClick: ($event: any) => (close())
+            }, [
+              _createElementVNode("span", null, _toDisplayString(_unref(format)('hello')), 1 /* TEXT */),
+              _createElementVNode("span", null, _toDisplayString(__props.renderLabel('x', _unref(format))), 1 /* TEXT */)
+            ], 10 /* CLASS, PROPS */, ["onClick"])
+          ]),
+          _: 1 /* STABLE */
+        })
+      ]),
+      _: 1 /* STABLE */
+    }))
+}
+}
+
+})

--- a/tests/snapshots/sfc/js/patches__imported_custom_directive_binding_in_script_setup.snap
+++ b/tests/snapshots/sfc/js/patches__imported_custom_directive_binding_in_script_setup.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, resolveDirective as _resolveDirective, withDirectives as _withDirectives } from "vue"
+
+import { vElementHover } from '@vueuse/components'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+
+return (_ctx: any,_cache: any) => {
+  const _directive_element_hover = vElementHover
+
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [ [_directive_element_hover, () => {}] ])
+}
+}
+
+})

--- a/tests/snapshots/sfc/js/patches__nullable_runtime_prop_types_keep_null.snap
+++ b/tests/snapshots/sfc/js/patches__nullable_runtime_prop_types_keep_null.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  props: {
+    activeKey: { type: [String, null], required: true },
+    items: { type: [Array, null], required: true },
+    groupName: { type: [String, null], required: true }
+  },
+  setup(__props: any) {
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div"))
+}
+}
+
+})

--- a/tests/snapshots/sfc/js/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
+++ b/tests/snapshots/sfc/js/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { class: "map" }, [
+    _createElementVNode("div", {
+      style: _normalizeStyle(_ctx.knobStyle),
+      class: _normalizeClass({ dragging: _ctx.dragging })
+    }, null, 6 /* CLASS, STYLE */)
+  ]))
+}
+
+const _sfc_main = {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+
+_sfc_main.render = render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
+++ b/tests/snapshots/sfc/js/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
@@ -1,0 +1,36 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle } from "vue"
+
+import { computed, ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const reference = ref<HTMLElement>()
+const floating = ref<HTMLElement>()
+const isOpen = ref(true)
+const klass = computed(() => 'x')
+const styles = computed(() => ({ left: '0px', top: '0px' }))
+function toggle() {}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [ (isOpen.value) ? (_openBlock(), _createElementBlock("button", {
+          key: 0,
+          ref_key: "reference", ref: reference,
+          id: isOpen.value ? 'open' : undefined,
+          class: _normalizeClass(["base", klass.value]),
+          onClick: toggle
+        }, "\n    open\n  ", 10 /* CLASS, PROPS */, ["id"])) : _createCommentVNode("v-if", true), (isOpen.value) ? (_openBlock(), _createElementBlock("div", {
+          key: 0,
+          ref_key: "floating", ref: floating,
+          style: _normalizeStyle(styles.value)
+        }, "\n    panel\n  ", 4 /* STYLE */)) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */))
+}
+}
+
+})

--- a/tests/snapshots/sfc/js/patches__v_for_template_else_interpolation_wraps_text_vnode.snap
+++ b/tests/snapshots/sfc/js/patches__v_for_template_else_interpolation_wraps_text_vnode.snap
@@ -1,0 +1,30 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, renderList as _renderList, toDisplayString as _toDisplayString } from "vue"
+
+const name = 'paper'
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+function splitByQuery(name) {
+  return [{ text: name, match: false }]
+}
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("p", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(splitByQuery(name), (seg, i) => {
+        return (_openBlock(), _createElementBlock(_Fragment, { key: i }, [
+          (seg.match)
+            ? (_openBlock(), _createElementBlock("mark", { key: 0 }, _toDisplayString(seg.text), 1 /* TEXT */))
+            : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [
+              _createTextVNode(_toDisplayString(seg.text), 1 /* TEXT */)
+            ], 64 /* STABLE_FRAGMENT */))
+        ], 64 /* STABLE_FRAGMENT */))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
+}
+}
+
+}

--- a/tests/snapshots/sfc/js/patches__v_if_branch_keeps_maybe_ref_style_patch_flag.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_branch_keeps_maybe_ref_style_patch_flag.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, normalizeStyle as _normalizeStyle } from "vue"
+
+import { ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const show = ref(true)
+const floatingStyles = ref({ left: '10px', top: '20px' })
+
+return (_ctx: any,_cache: any) => {
+  return (show.value)
+      ? (_openBlock(), _createElementBlock("div", {
+        key: 0,
+        style: _normalizeStyle(floatingStyles.value)
+      }, null, 4 /* STYLE */))
+      : _createCommentVNode("v-if", true)
+}
+}
+
+})

--- a/tests/snapshots/sfc/js/patches__v_if_slot_outlet_with_v_else.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_slot_outlet_with_v_else.snap
@@ -13,7 +13,7 @@ export default {
 const showing = ref(false)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0 }) : _renderSlot(_ctx.$slots, "fallback", { key: 1 }) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0}) : _renderSlot(_ctx.$slots, "fallback", { key: 1}) ]))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_model_on_input.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_model_on_input.snap
@@ -18,7 +18,7 @@ return (_ctx, _cache) => {
       ? _withDirectives((_openBlock(), _createElementBlock("input", {
         key: 0,
         "onUpdate:modelValue": _cache[0] || (_cache[0] = $event => ((text).value = $event))
-      })), [ [_vModelText, text.value] ])
+      }, null, 512 /* NEED_PATCH */)), [ [_vModelText, text.value] ])
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/patches__component_event_member_expression_handler_is_invoked.snap
+++ b/tests/snapshots/sfc/ts/patches__component_event_member_expression_handler_is_invoked.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, resolveComponent as _resolveComponent, unref as _unref } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const actionHandler = useActionHandler()
+
+return (_ctx: any,_cache: any) => {
+  const _component_ActionPanel = _resolveComponent("ActionPanel")
+
+  return (_openBlock(), _createBlock(_component_ActionPanel, {
+      onSelectItem: _cache[0] || (_cache[0] = (...args) => (_unref(actionHandler).selectItem && _unref(actionHandler).selectItem(...args)))
+    }))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__component_event_rest_params_stay_local.snap
+++ b/tests/snapshots/sfc/ts/patches__component_event_rest_params_stay_local.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, resolveComponent as _resolveComponent, unref as _unref } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  emits: ["update"],
+  setup(__props, { emit: __emit }) {
+
+const emit = __emit
+
+return (_ctx: any,_cache: any) => {
+  const _component_Child = _resolveComponent("Child")
+
+  return (_openBlock(), _createBlock(_component_Child, {
+      onUpdate: _cache[0] || (_cache[0] = (...$args) => _unref(emit)('update', ...$args)),
+      onChange: _cache[1] || (_cache[1] = (...args) => _unref(emit)('update', ...args))
+    }))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__dynamic_asset_url_with_import_meta_url.snap
+++ b/tests/snapshots/sfc/ts/patches__dynamic_asset_url_with_import_meta_url.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const getBrandLogoUrl = (type, theme) => {
+  return new URL(`../../assets/logos/brand_${type}_${theme}.svg`, import.meta.url).href
+}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("img", {
+      src: getBrandLogoUrl('alpha', 'light'),
+      alt: "brand logo"
+    }, null, 8 /* PROPS */, ["src"]))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__dynamic_slot_outlet_name_in_loop.snap
+++ b/tests/snapshots/sfc/ts/patches__dynamic_slot_outlet_name_in_loop.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, renderList as _renderList, renderSlot as _renderSlot } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const tabs = [
+  { key: 'basic', label: 'Basic' },
+  { key: 'parts', label: 'Parts' },
+]
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs, (tab) => {
+        return (_openBlock(), _createElementBlock(_Fragment, { key: tab.key }, [
+          _renderSlot(_ctx.$slots, tab.key, {tab: tab})
+        ], 64 /* STABLE_FRAGMENT */))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__function_typed_prop_param_does_not_shadow_local_t.snap
+++ b/tests/snapshots/sfc/ts/patches__function_typed_prop_param_does_not_shadow_local_t.snap
@@ -1,0 +1,43 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createBlock as _createBlock, createVNode as _createVNode, createElementVNode as _createElementVNode, resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, withCtx as _withCtx, unref as _unref } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  props: {
+    renderLabel: { type: Function, required: true }
+  },
+  setup(__props: any) {
+
+const props = __props
+const { format } = useFormatter(catalog)
+
+return (_ctx: any,_cache: any) => {
+  const _component_OptionRow = _resolveComponent("OptionRow")
+  const _component_PopupMenu = _resolveComponent("PopupMenu")
+
+  return (_openBlock(), _createBlock(_component_PopupMenu, null, {
+      items: _withCtx(({ close }) => [
+        _createVNode(_component_OptionRow, null, {
+          default: _withCtx(({ active }) => [
+            _createElementVNode("li", {
+              class: _normalizeClass({ active: active }),
+              onClick: ($event: any) => (close())
+            }, [
+              _createElementVNode("span", null, _toDisplayString(_unref(format)('hello')), 1 /* TEXT */),
+              _createElementVNode("span", null, _toDisplayString(__props.renderLabel('x', _unref(format))), 1 /* TEXT */)
+            ], 10 /* CLASS, PROPS */, ["onClick"])
+          ]),
+          _: 1 /* STABLE */
+        })
+      ]),
+      _: 1 /* STABLE */
+    }))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__imported_custom_directive_binding_in_script_setup.snap
+++ b/tests/snapshots/sfc/ts/patches__imported_custom_directive_binding_in_script_setup.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, resolveDirective as _resolveDirective, withDirectives as _withDirectives } from "vue"
+
+import { vElementHover } from '@vueuse/components'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+
+return (_ctx: any,_cache: any) => {
+  const _directive_element_hover = vElementHover
+
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [ [_directive_element_hover, () => {}] ])
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__nullable_runtime_prop_types_keep_null.snap
+++ b/tests/snapshots/sfc/ts/patches__nullable_runtime_prop_types_keep_null.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  props: {
+    activeKey: { type: [String, null], required: true },
+    items: { type: [Array, null], required: true },
+    groupName: { type: [String, null], required: true }
+  },
+  setup(__props: any) {
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div"))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
+++ b/tests/snapshots/sfc/ts/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { class: "map" }, [
+    _createElementVNode("div", {
+      style: _normalizeStyle(_ctx.knobStyle),
+      class: _normalizeClass({ dragging: _ctx.dragging })
+    }, null, 6 /* CLASS, STYLE */)
+  ]))
+}
+
+const _sfc_main = {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+
+_sfc_main.render = render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
+++ b/tests/snapshots/sfc/ts/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
@@ -1,0 +1,36 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle } from "vue"
+
+import { computed, ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const reference = ref<HTMLElement>()
+const floating = ref<HTMLElement>()
+const isOpen = ref(true)
+const klass = computed(() => 'x')
+const styles = computed(() => ({ left: '0px', top: '0px' }))
+function toggle() {}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [ (isOpen.value) ? (_openBlock(), _createElementBlock("button", {
+          key: 0,
+          ref_key: "reference", ref: reference,
+          id: isOpen.value ? 'open' : undefined,
+          class: _normalizeClass(["base", klass.value]),
+          onClick: toggle
+        }, "\n    open\n  ", 10 /* CLASS, PROPS */, ["id"])) : _createCommentVNode("v-if", true), (isOpen.value) ? (_openBlock(), _createElementBlock("div", {
+          key: 0,
+          ref_key: "floating", ref: floating,
+          style: _normalizeStyle(styles.value)
+        }, "\n    panel\n  ", 4 /* STYLE */)) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__v_for_template_else_interpolation_wraps_text_vnode.snap
+++ b/tests/snapshots/sfc/ts/patches__v_for_template_else_interpolation_wraps_text_vnode.snap
@@ -1,0 +1,31 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, renderList as _renderList, toDisplayString as _toDisplayString } from "vue"
+
+const name = 'paper'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+function splitByQuery(name) {
+  return [{ text: name, match: false }]
+}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("p", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(splitByQuery(name), (seg, i) => {
+        return (_openBlock(), _createElementBlock(_Fragment, { key: i }, [
+          (seg.match)
+            ? (_openBlock(), _createElementBlock("mark", { key: 0 }, _toDisplayString(seg.text), 1 /* TEXT */))
+            : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [
+              _createTextVNode(_toDisplayString(seg.text), 1 /* TEXT */)
+            ], 64 /* STABLE_FRAGMENT */))
+        ], 64 /* STABLE_FRAGMENT */))
+      }), 128 /* KEYED_FRAGMENT */)) ]))
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__v_if_branch_keeps_maybe_ref_style_patch_flag.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_branch_keeps_maybe_ref_style_patch_flag.snap
@@ -1,0 +1,27 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, normalizeStyle as _normalizeStyle } from "vue"
+
+import { ref } from 'vue'
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+const show = ref(true)
+const floatingStyles = ref({ left: '10px', top: '20px' })
+
+return (_ctx: any,_cache: any) => {
+  return (show.value)
+      ? (_openBlock(), _createElementBlock("div", {
+        key: 0,
+        style: _normalizeStyle(floatingStyles.value)
+      }, null, 4 /* STYLE */))
+      : _createCommentVNode("v-if", true)
+}
+}
+
+})

--- a/tests/snapshots/sfc/ts/patches__v_if_slot_outlet_with_v_else.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_slot_outlet_with_v_else.snap
@@ -14,7 +14,7 @@ export default /*@__PURE__*/_defineComponent({
 const showing = ref(false)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0 }) : _renderSlot(_ctx.$slots, "fallback", { key: 1 }) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0}) : _renderSlot(_ctx.$slots, "fallback", { key: 1}) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_model_on_input.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_model_on_input.snap
@@ -19,7 +19,7 @@ return (_ctx: any,_cache: any) => {
       ? _withDirectives((_openBlock(), _createElementBlock("input", {
         key: 0,
         "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event: any) => ((text).value = $event))
-      })), [ [_vModelText, text.value] ])
+      }, null, 512 /* NEED_PATCH */)), [ [_vModelText, text.value] ])
       : _createCommentVNode("v-if", true)
 }
 }

--- a/tests/snapshots/sfc/ts/script_setup__props_with_method_signatures_in_object.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_method_signatures_in_object.snap
@@ -9,7 +9,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, cre
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    context: { type: Object, required: true }
+    context: { type: Object as PropType<{ open(): void; close(): void; isOpened: boolean }>, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_nested_object_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_nested_object_types.snap
@@ -9,7 +9,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, toD
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    config: { type: Object, required: true }
+    config: { type: Object as PropType<{ state: string; disabled: boolean; onSuccess?: () => void }>, required: true }
   },
   setup(__props: any) {
 


### PR DESCRIPTION
## 概要
Vite 8 / Rolldown 環境で見つかった Vize 側の互換性問題をまとめて修正した PR です。

今回の方針は、単発の unit test ではなく、既存の `tests/fixtures/sfc/patches.toml` と `tests/snapshots/sfc/{js,ts}` に回帰ケースを追加して、snapshot harness に合わせて固定することです。

## パッチ内容
### 1. slot / v-if / child codegen の修正
- dynamic slot outlet name を正しく出力するよう修正
  - `<slot :name="tab.key" />` が `default` 固定にならず、`tab.key` をそのまま `renderSlot` に渡す
- `v-for + template v-else + interpolation` で raw string child を作らず、`createTextVNode(...)` を出すよう修正
- `v-if` branch の通常 element 経路でも、block/inline element と同様に patch flag / dynamic props を出力するよう修正
- `v-if` branch 上の custom directive / `v-model` / `v-show` が wrapper ごと落ちないよう修正
- `v-if` branch の単一 text/interpolation child で patch flag を二重に出さないよう修正
- forwarding slot / slot children の扱いを整理し、空白 text / comment を落とすよう修正
- slot render 中の handler cache 判定を改善

### 2. template expression / event handler まわりの修正
- component event handler の member expression を no-op wrapper にしないよう修正
- rest parameter を含む inline handler で `...args` / `...$args` を `_ctx.args` / `_ctx.$args` に誤変換しないよう修正
- function-typed prop parameter 名と local binding が衝突しても、local binding を props に誤解釈しないよう修正
- imported custom directive binding を `_resolveDirective()` に落とさず、import binding をそのまま使うよう修正

### 3. template ref / dynamic style-class / patch flag の修正
- `ref="reference"` / `ref="floating"` を setup ref binding に正しく結びつけるよう修正
- dynamic props を持つ `v-if` branch 上でも template ref が落ちないよう修正
- transform 後の `_ctx.xxx` / `$setup.xxx` / `__props.xxx` を定数扱いしないようにして、dynamic `style` / `class` の patch flag を保持
- options API / script setup の両方で dynamic `style` / `class` の patch flag が消えないよう修正

### 4. script / props compile の修正
- multiline object literal 判定を厳密化し、function block を object literal と誤判定しないよう修正
- `inject<Ref<T>>` / `inject(..., ref(...))` を `SetupMaybeRef` として扱い、template 側で `.value` を正しく付与
- nullable runtime prop type を保持するよう修正
  - `string | null` -> `type: [String, null]`
  - `string[] | null` -> `type: [Array, null]`
- object 型 prop の runtime snapshot を `Object as PropType<...>` 側に更新

### 5. vite-plugin-vize / Vite 8 互換修正
- virtual module 内の dynamic `new URL(..., import.meta.url)` を、root-absolute な `import.meta.glob(..., { query: '?url' })` に先回り変換
  - Rolldown の `In virtual modules, all globs must start with '/'` を回避
- build 時 style request の null byte 扱いを調整し、plugin-vue descriptor 読み込みエラーを回避
- style block index 計算を descriptor 実態に合わせて補正
- compat path の post-transform 対象判定を厳密化

### 6. vapor / native package の修正
- vapor の event listener prop 生成で handler を余計な getter で包まないよう修正
- `npm/vize-native/package.json` に native `.node` binary を含めるよう修正

## snapshot / fixture 追加
`tests/fixtures/sfc/patches.toml` に以下のケースを追加し、`tests/snapshots/sfc/js` と `tests/snapshots/sfc/ts` を更新しました。
- dynamic asset URL with import meta url
- dynamic slot outlet name in loop
- v for template else interpolation wraps text vnode
- imported custom directive binding in script setup
- v if branch keeps maybe ref style patch flag
- template ref with dynamic props in v if branch
- options api dynamic style and class keep patch flags
- component event member expression handler is invoked
- component event rest params stay local
- function typed prop param does not shadow local t
- nullable runtime prop types keep null

既存ケースの snapshot 更新も含みます。
- `patches__v_if_with_v_model_on_input`
- `patches__v_if_slot_outlet_with_v_else`
- `script_setup__props_with_method_signatures_in_object`
- `script_setup__props_with_nested_object_types`

## テスト
- `cargo test -p vize_atelier_sfc test_patches_js_snapshots`
- `cargo test -p vize_atelier_sfc test_patches_ts_snapshots`
